### PR TITLE
Remove `connected?` in `Setlists.ShowLive`

### DIFF
--- a/lib/setlistify/setlist_fm/api.ex
+++ b/lib/setlistify/setlist_fm/api.ex
@@ -19,10 +19,14 @@ defmodule Setlistify.SetlistFm.API do
           songs: [String.t()]
         }
   @callback search(String.t()) :: [search_result()]
-  def search(query), do: impl().search(query)
+  def search(query) do
+    :setlist_fm_search_cache |> Cachex.fetch(query, &impl().search/1) |> elem(1)
+  end
 
   @callback get_setlist(String.t()) :: setlist()
-  def get_setlist(id), do: impl().get_setlist(id)
+  def get_setlist(id) do
+    :setlist_fm_setlist_cache |> Cachex.fetch(id, &impl().get_setlist/1) |> elem(1)
+  end
 
   defp impl do
     Application.get_env(

--- a/lib/setlistify/setlist_fm/api/external_client.ex
+++ b/lib/setlistify/setlist_fm/api/external_client.ex
@@ -4,49 +4,43 @@ defmodule Setlistify.SetlistFm.API.ExternalClient do
   @root_endpoint "https://api.setlist.fm/rest/1.0"
 
   def search(query, endpoint \\ @root_endpoint) do
-    Cachex.fetch(:setlist_fm_search_cache, query, fn query ->
-      %{"setlist" => setlists} =
-        Req.get!(request(endpoint), url: "/search/setlists", params: %{"artistName" => query}).body
+    %{"setlist" => setlists} =
+      Req.get!(request(endpoint), url: "/search/setlists", params: %{"artistName" => query}).body
 
-      Enum.map(setlists, fn setlist ->
-        %{
-          "artist" => %{"name" => artist_name},
-          "eventDate" => date,
-          "id" => id,
-          "venue" => %{"name" => venue_name}
-        } = setlist
+    Enum.map(setlists, fn setlist ->
+      %{
+        "artist" => %{"name" => artist_name},
+        "eventDate" => date,
+        "id" => id,
+        "venue" => %{"name" => venue_name}
+      } = setlist
 
-        %{artist: artist_name, date: format_date(date), id: id, venue: %{name: venue_name}}
-      end)
+      %{artist: artist_name, date: format_date(date), id: id, venue: %{name: venue_name}}
     end)
-    |> elem(1)
   end
 
   def get_setlist(id, endpoint \\ @root_endpoint) do
-    Cachex.fetch(:setlist_fm_setlist_cache, id, fn id ->
-      resp = Req.get!(request(endpoint), url: "/setlist/#{id}").body
+    resp = Req.get!(request(endpoint), url: "/setlist/#{id}").body
 
-      %{
-        "artist" => %{"name" => artist_name},
-        "venue" => %{"name" => venue_name},
-        "eventDate" => date,
-        # The [docs](https://api.setlist.fm/docs/1.0/json_Setlist.html) do not
-        # indicate there is a "sets" key, but only a "set" key which is an array
-        # of set resources. For now, I am going to assume this is essentially an
-        # extraneous key and we can dig into the sub-"set" array and not miss out
-        # on anything.
-        "sets" => %{"set" => sets}
-      } = resp
+    %{
+      "artist" => %{"name" => artist_name},
+      "venue" => %{"name" => venue_name},
+      "eventDate" => date,
+      # The [docs](https://api.setlist.fm/docs/1.0/json_Setlist.html) do not
+      # indicate there is a "sets" key, but only a "set" key which is an array
+      # of set resources. For now, I am going to assume this is essentially an
+      # extraneous key and we can dig into the sub-"set" array and not miss out
+      # on anything.
+      "sets" => %{"set" => sets}
+    } = resp
 
-      sets =
-        Enum.map(sets, fn set ->
-          songs = set |> Map.get("song", []) |> Enum.map(&Map.get(&1, "name"))
-          %{name: set["name"], encore: set["encore"], songs: songs}
-        end)
+    sets =
+      Enum.map(sets, fn set ->
+        songs = set |> Map.get("song", []) |> Enum.map(&Map.get(&1, "name"))
+        %{name: set["name"], encore: set["encore"], songs: songs}
+      end)
 
-      %{artist: artist_name, venue: %{name: venue_name}, date: format_date(date), sets: sets}
-    end)
-    |> elem(1)
+    %{artist: artist_name, venue: %{name: venue_name}, date: format_date(date), sets: sets}
   end
 
   defp request(endpoint) do

--- a/lib/setlistify_web/live/setlists/show_live.ex
+++ b/lib/setlistify_web/live/setlists/show_live.ex
@@ -4,41 +4,33 @@ defmodule SetlistifyWeb.Setlists.ShowLive do
   alias Setlistify.SetlistFm
 
   def mount(%{"id" => id}, _session, socket) do
-    if connected?(socket) do
-      {:ok, assign(socket, setlist: SetlistFm.API.get_setlist(id))}
-    else
-      {:ok, assign(socket, setlist: nil)}
-    end
+    {:ok, assign(socket, setlist: SetlistFm.API.get_setlist(id))}
   end
 
   def render(assigns) do
     ~H"""
-    <%= if !@setlist do %>
-      Fetching setlist...
+    <%= if @music_account do %>
+      <button type="button">Create Playlist</button>
     <% else %>
-      <%= if @music_account do %>
-        <button type="button">Create Playlist</button>
-      <% else %>
-        <.link navigate={~p"/signin/spotify?redirect_to=#{@redirect_to}"}>
-          Sign in to Spotify to Create Playlist
-        </.link>
-      <% end %>
-      <hr />
-      <%= @setlist.artist %> @ <%= @setlist.venue.name %> on <%= @setlist.date %>
+      <.link navigate={~p"/signin/spotify?redirect_to=#{@redirect_to}"}>
+        Sign in to Spotify to Create Playlist
+      </.link>
+    <% end %>
+    <hr />
+    <%= @setlist.artist %> @ <%= @setlist.venue.name %> on <%= @setlist.date %>
 
-      <h2>Sets</h2>
+    <h2>Sets</h2>
 
-      <%= for set <- @setlist.sets do %>
-        <article>
-          <h2><%= set_name(set) %></h2>
+    <%= for set <- @setlist.sets do %>
+      <article>
+        <h2><%= set_name(set) %></h2>
 
-          <ol>
-            <%= for song <- set.songs do %>
-              <li><%= song %></li>
-            <% end %>
-          </ol>
-        </article>
-      <% end %>
+        <ol>
+          <%= for song <- set.songs do %>
+            <li><%= song %></li>
+          <% end %>
+        </ol>
+      </article>
     <% end %>
     """
   end

--- a/test/setlistify_web/live/search_live_test.exs
+++ b/test/setlistify_web/live/search_live_test.exs
@@ -1,12 +1,17 @@
 defmodule SetlistifyWeb.SearchLiveTest do
-  use SetlistifyWeb.ConnCase, async: true
+  use SetlistifyWeb.ConnCase, async: false
 
   import Phoenix.LiveViewTest
   import Hammox
 
   alias Setlistify.SetlistFm
 
-  # Make sure mocks are verified when the test exits
+  # Cache fetching happens in another process, managed by Cachex. The process we
+  # start in our application tree is a supervisor, so explictly `allow`ing with
+  # that PID does not work. This will enable "global" mode which means  any
+  # process will respect our `expect` at the cost of not being able to run with
+  # `async: true`
+  setup :set_mox_from_context
   setup :verify_on_exit!
 
   test "searching for setlists", %{conn: conn} do

--- a/test/setlistify_web/live/setlists/show_live_test.exs
+++ b/test/setlistify_web/live/setlists/show_live_test.exs
@@ -1,11 +1,17 @@
 defmodule SetlistifyWeb.Setlists.ShowLiveTest do
-  use SetlistifyWeb.ConnCase, async: true
+  use SetlistifyWeb.ConnCase, async: false
 
   import Phoenix.LiveViewTest
   import Hammox
 
   alias Setlistify.SetlistFm
 
+  # Cache fetching happens in another process, managed by Cachex. The process we
+  # start in our application tree is a supervisor, so explictly `allow`ing with
+  # that PID does not work. This will enable "global" mode which means  any
+  # process will respect our `expect` at the cost of not being able to run with
+  # `async: true`
+  setup :set_mox_from_context
   setup :verify_on_exit!
 
   test "viewing a setlist", %{conn: conn} do


### PR DESCRIPTION
We had a `connected?` check in our `ShowLive` mount callback to avoid hitting the API twice. Since we have implemented caching, we should no longer hit the API twice (though we will hit the cache unnecessarily). Since the cache check should be quick and it cleans up the code, we moved the `connected?` check from `ShowLive` and fetch the setlist on the first render.

As a part of this move, our expectation for a single call to our mock API client was no longer true (it would be called twice now, once on first mount and again on the socket connected mount). As an indication that we didn't want to make two API calls our test `expects` explicitly called out expecting it to be called once. Rather than updating this to two for our test (which may be confusing) or removing the call count altogether, we move the API caching out of the actual implementation (`ExternalClient`) and into `SetlistFm.API`. This makes our test/mock client behave more similarly to our actual client in that it will also leverage a caching layer. This came at the cost of having to have (Ham)mox work in "global mode"[^1] which means we can no longer run these tests in async. Since the project is still small, there isn't a noticeable cost to this.

[^1]: https://hexdocs.pm/mox/Mox.html#module-global-mode