### PR TITLE
fix: fix `tid` helper in prod build

### DIFF
--- a/lib/setlistify_web.ex
+++ b/lib/setlistify_web.ex
@@ -98,7 +98,7 @@ defmodule SetlistifyWeb do
       # WARNING: If you change the pattern, you may need to update our selector
       # in `SetlistifyWeb.ConnCase`
       if Mix.env() == :prod do
-        def tid(), do: []
+        def tid(_), do: []
       else
         def tid(list) when is_list(list), do: [{:data, ["test-#{Enum.join(list, "-")}": true]}]
         def tid(id), do: [{:data, ["test-#{id}": true]}]


### PR DESCRIPTION
The `tid/0` helper for the production builds did not match the `tid/1` helper used in other environments. This change updates the production helper function to be a one-arity function to match the arity of the others.