### PR TITLE
config: make dev server port configurable via environment variable

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -9,7 +9,7 @@ import Config
 config :setlistify, SetlistifyWeb.Endpoint,
   # Binding to loopback ipv4 address prevents access from other machines.
   # Change to `ip: {0, 0, 0, 0}` to allow access from other machines.
-  http: [ip: {127, 0, 0, 1}, port: 4000],
+  http: [ip: {127, 0, 0, 1}, port: System.get_env("PORT") || 4000],
   check_origin: false,
   code_reloader: true,
   debug_errors: true,


### PR DESCRIPTION
## Summary
- Allow PORT environment variable to override default port 4000
- Enables running multiple instances or deployment flexibility

## Test plan
1. Run `mix phx.server` (should default to port 4000)
2. Run `PORT=4001 mix phx.server` (should use port 4001)

🤖 Generated with [Claude Code](https://claude.ai/code)