### PR TITLE
Add song count and venue location to setlist search results

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,4 +89,4 @@ These values are automatically loaded from `.env` in development. You can copy `
 
 - run mix format after making changes
 - mix test to run all tests
-- Run format frequently to avoid style warnings
+- Run format frequently to avoid style warnings, especially before planning to commit

--- a/lib/setlistify/setlist_fm/api.ex
+++ b/lib/setlistify/setlist_fm/api.ex
@@ -16,7 +16,14 @@ defmodule Setlistify.SetlistFm.API do
 
   @type setlist() :: %{
           artist: String.t(),
-          venue: %{name: String.t()},
+          venue: %{
+            name: String.t(),
+            location: %{
+              city: String.t(),
+              state: String.t() | nil,
+              country: String.t()
+            }
+          },
           date: Date.t(),
           sets: [set()]
         }

--- a/lib/setlistify/setlist_fm/api.ex
+++ b/lib/setlistify/setlist_fm/api.ex
@@ -1,9 +1,17 @@
 defmodule Setlistify.SetlistFm.API do
   @type search_result() :: %{
           artist: String.t(),
-          venue: %{name: String.t()},
+          venue: %{
+            name: String.t(),
+            location: %{
+              city: String.t(),
+              state: String.t() | nil,
+              country: String.t()
+            }
+          },
           date: Date.t(),
-          id: String.t()
+          id: String.t(),
+          song_count: non_neg_integer()
         }
 
   @type setlist() :: %{

--- a/lib/setlistify/setlist_fm/api/external_client.ex
+++ b/lib/setlistify/setlist_fm/api/external_client.ex
@@ -12,10 +12,27 @@ defmodule Setlistify.SetlistFm.API.ExternalClient do
         "artist" => %{"name" => artist_name},
         "eventDate" => date,
         "id" => id,
-        "venue" => %{"name" => venue_name}
+        "venue" => %{
+          "name" => venue_name,
+          "city" => city_data
+        },
+        "sets" => %{"set" => sets}
       } = setlist
 
-      %{artist: artist_name, date: format_date(date), id: id, venue: %{name: venue_name}}
+      song_count =
+        sets
+        |> Enum.flat_map(&Map.get(&1, "song", []))
+        |> length()
+
+      location = build_location(city_data)
+
+      %{
+        artist: artist_name,
+        date: format_date(date),
+        id: id,
+        venue: %{name: venue_name, location: location},
+        song_count: song_count
+      }
     end)
   end
 
@@ -60,5 +77,24 @@ defmodule Setlistify.SetlistFm.API.ExternalClient do
   defp format_date(date) do
     %{"year" => year, "month" => month, "day" => day} = Regex.named_captures(@date_regex, date)
     Date.new!(String.to_integer(year), String.to_integer(month), String.to_integer(day))
+  end
+
+  defp build_location(city_data) do
+    city_name = Map.get(city_data, "name", "Unknown")
+
+    country_name =
+      case Map.get(city_data, "country") do
+        %{"name" => name} -> name
+        _ -> "Unknown"
+      end
+
+    # stateCode is optional - only present for certain countries like US, Canada, etc.
+    state_code = Map.get(city_data, "stateCode")
+
+    %{
+      city: city_name,
+      state: state_code,
+      country: country_name
+    }
   end
 end

--- a/lib/setlistify/setlist_fm/api/external_client.ex
+++ b/lib/setlistify/setlist_fm/api/external_client.ex
@@ -41,7 +41,7 @@ defmodule Setlistify.SetlistFm.API.ExternalClient do
 
     %{
       "artist" => %{"name" => artist_name},
-      "venue" => %{"name" => venue_name},
+      "venue" => %{"name" => venue_name, "city" => city_data},
       "eventDate" => date,
       # The [docs](https://api.setlist.fm/docs/1.0/json_Setlist.html) do not
       # indicate there is a "sets" key, but only a "set" key which is an array
@@ -57,7 +57,14 @@ defmodule Setlistify.SetlistFm.API.ExternalClient do
         %{name: set["name"], encore: set["encore"], songs: songs}
       end)
 
-    %{artist: artist_name, venue: %{name: venue_name}, date: format_date(date), sets: sets}
+    location = build_location(city_data)
+
+    %{
+      artist: artist_name,
+      venue: %{name: venue_name, location: location},
+      date: format_date(date),
+      sets: sets
+    }
   end
 
   defp request(endpoint) do

--- a/lib/setlistify_web/live/search_live.ex
+++ b/lib/setlistify_web/live/search_live.ex
@@ -53,7 +53,12 @@ defmodule SetlistifyWeb.SearchLive do
             </time>
             <div class="self-center space-y-1">
               <div class="text-lg">{setlist.artist}</div>
-              <div class="font-light text-slate-400">{setlist.venue.name}</div>
+              <div class="font-light text-slate-400">
+                {setlist.venue.name}
+                <span class="text-slate-300">
+                  • {format_location(setlist.venue.location)}
+                </span>
+              </div>
             </div>
           </li>
         </.link>
@@ -73,5 +78,11 @@ defmodule SetlistifyWeb.SearchLive do
     |> Ecto.Changeset.cast(params, Map.keys(types))
     |> Ecto.Changeset.validate_required(Map.keys(types))
     |> Map.put(:action, :validate)
+  end
+
+  defp format_location(%{city: city, state: state, country: country}) do
+    [city, state, country]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join(", ")
   end
 end

--- a/lib/setlistify_web/live/search_live.ex
+++ b/lib/setlistify_web/live/search_live.ex
@@ -1,5 +1,6 @@
 defmodule SetlistifyWeb.SearchLive do
   use SetlistifyWeb, :live_view
+  use Gettext, backend: SetlistifyWeb.Gettext
 
   def mount(_params, _session, socket) do
     {:ok, assign(socket, setlists: [], search: search_form(%{}))}
@@ -52,7 +53,12 @@ defmodule SetlistifyWeb.SearchLive do
               <div class="py-3">{setlist.date.day}</div>
             </time>
             <div class="self-center space-y-1">
-              <div class="text-lg">{setlist.artist}</div>
+              <div class="text-lg">
+                {setlist.artist}
+                <span class="text-sm text-slate-500 ml-2">
+                  {format_song_count(setlist.song_count)}
+                </span>
+              </div>
               <div class="font-light text-slate-400">
                 {setlist.venue.name}
                 <span class="text-slate-300">
@@ -84,5 +90,9 @@ defmodule SetlistifyWeb.SearchLive do
     [city, state, country]
     |> Enum.reject(&is_nil/1)
     |> Enum.join(", ")
+  end
+
+  defp format_song_count(count) do
+    ngettext("1 song", "%{count} songs", count)
   end
 end

--- a/lib/setlistify_web/live/setlists/show_live.ex
+++ b/lib/setlistify_web/live/setlists/show_live.ex
@@ -37,6 +37,7 @@ defmodule SetlistifyWeb.Setlists.ShowLive do
        sets: setlist.sets,
        artist: setlist.artist,
        venue_name: setlist.venue.name,
+       venue_location: setlist.venue.location,
        date: setlist.date
      )}
   end
@@ -81,7 +82,8 @@ defmodule SetlistifyWeb.Setlists.ShowLive do
 
   def render(assigns) do
     ~H"""
-    <h1 class="mb-3 text-2xl">{@artist} @ {@venue_name} on {@date}</h1>
+    <h1 class="mb-3 text-2xl">{@artist} @ {@venue_name}</h1>
+    <p class="mb-3 text-slate-500">{format_location(@venue_location)} • {@date}</p>
 
     <div class="space-y-3 mb-6">
       <%= for set <- @sets do %>
@@ -130,4 +132,10 @@ defmodule SetlistifyWeb.Setlists.ShowLive do
   defp set_name(%{encore: encore}) when is_number(encore), do: "Encore #{encore}"
   defp set_name(%{name: nil}), do: "Unnamed Setlist"
   defp set_name(%{name: name}), do: name
+
+  defp format_location(%{city: city, state: state, country: country}) do
+    [city, state, country]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join(", ")
+  end
 end

--- a/test/setlistify/setlist_fm/api/external_client_test.exs
+++ b/test/setlistify/setlist_fm/api/external_client_test.exs
@@ -26,6 +26,12 @@ defmodule Setlistify.SetlistFm.API.ExternalClientTest do
     assert event.venue.name == "9:30 Club"
     assert event.date == Date.new!(2022, 12, 20)
     assert event.id
+
+    # Check total song count - the first setlist has 15 + 5 = 20 songs total
+    assert event.song_count == 20
+
+    # Check venue location
+    assert event.venue.location == "Washington, United States"
   end
 
   @get_response fixture_dir() |> Path.join("setlist_fm_setlist_response.json") |> File.read!()

--- a/test/setlistify/setlist_fm/api/external_client_test.exs
+++ b/test/setlistify/setlist_fm/api/external_client_test.exs
@@ -31,7 +31,97 @@ defmodule Setlistify.SetlistFm.API.ExternalClientTest do
     assert event.song_count == 20
 
     # Check venue location
-    assert event.venue.location == "Washington, United States"
+    assert event.venue.location.city == "Washington"
+    assert event.venue.location.state == "DC"
+    assert event.venue.location.country == "United States"
+  end
+
+  test "search/1 handles international venues without state" do
+    # Create a response with different venue formats
+    response = %{
+      "setlist" => [
+        %{
+          "artist" => %{"name" => "The Beatles"},
+          "eventDate" => "01-01-2023",
+          "id" => "test-id-1",
+          "venue" => %{
+            "name" => "Royal Albert Hall",
+            "city" => %{
+              "name" => "London",
+              "country" => %{"name" => "United Kingdom"}
+              # Note: no stateCode for UK venues
+            }
+          },
+          "sets" => %{"set" => [%{"song" => [%{"name" => "Hey Jude"}]}]}
+        },
+        %{
+          "artist" => %{"name" => "The Beatles"},
+          "eventDate" => "02-01-2023",
+          "id" => "test-id-2",
+          "venue" => %{
+            "name" => "Maple Leaf Gardens",
+            "city" => %{
+              "name" => "Toronto",
+              "stateCode" => "ON",
+              "country" => %{"name" => "Canada"}
+            }
+          },
+          "sets" => %{"set" => [%{"song" => [%{"name" => "Let It Be"}]}]}
+        }
+      ]
+    }
+
+    Req.Test.stub(MySetlistFmStub, fn
+      %{request_path: "/rest/1.0/search/setlists", method: "GET"} = conn ->
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(response))
+    end)
+
+    [uk_event, canada_event] = ExternalClient.search("beatles")
+
+    # UK venue without state
+    assert uk_event.venue.location.city == "London"
+    assert uk_event.venue.location.state == nil
+    assert uk_event.venue.location.country == "United Kingdom"
+
+    # Canadian venue with state
+    assert canada_event.venue.location.city == "Toronto"
+    assert canada_event.venue.location.state == "ON"
+    assert canada_event.venue.location.country == "Canada"
+  end
+
+  test "search/1 handles missing or malformed venue data" do
+    response = %{
+      "setlist" => [
+        %{
+          "artist" => %{"name" => "Test Artist"},
+          "eventDate" => "01-01-2023",
+          "id" => "test-id",
+          "venue" => %{
+            "name" => "Test Venue",
+            # Empty city data
+            "city" => %{}
+          },
+          "sets" => %{"set" => []}
+        }
+      ]
+    }
+
+    Req.Test.stub(MySetlistFmStub, fn
+      %{request_path: "/rest/1.0/search/setlists", method: "GET"} = conn ->
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(response))
+    end)
+
+    [event] = ExternalClient.search("test")
+
+    # Should handle missing data gracefully
+    assert event.venue.location.city == "Unknown"
+    assert event.venue.location.state == nil
+    assert event.venue.location.country == "Unknown"
+    assert event.song_count == 0
   end
 
   @get_response fixture_dir() |> Path.join("setlist_fm_setlist_response.json") |> File.read!()

--- a/test/setlistify/setlist_fm/api/external_client_test.exs
+++ b/test/setlistify/setlist_fm/api/external_client_test.exs
@@ -124,6 +124,204 @@ defmodule Setlistify.SetlistFm.API.ExternalClientTest do
     assert event.song_count == 0
   end
 
+  test "search/1 correctly calculates song counts for various set configurations" do
+    response = %{
+      "setlist" => [
+        # Setlist with no songs
+        %{
+          "artist" => %{"name" => "Test Artist"},
+          "eventDate" => "01-01-2023",
+          "id" => "test-id-1",
+          "venue" => %{
+            "name" => "Empty Venue",
+            "city" => %{
+              "name" => "Austin",
+              "stateCode" => "TX",
+              "country" => %{"name" => "United States"}
+            }
+          },
+          "sets" => %{"set" => []}
+        },
+        # Setlist with one set
+        %{
+          "artist" => %{"name" => "Test Artist"},
+          "eventDate" => "02-01-2023",
+          "id" => "test-id-2",
+          "venue" => %{
+            "name" => "Single Set Venue",
+            "city" => %{
+              "name" => "Seattle",
+              "stateCode" => "WA",
+              "country" => %{"name" => "United States"}
+            }
+          },
+          "sets" => %{
+            "set" => [
+              %{
+                "name" => "Main Set",
+                "song" => [
+                  %{"name" => "Song 1"},
+                  %{"name" => "Song 2"},
+                  %{"name" => "Song 3"}
+                ]
+              }
+            ]
+          }
+        },
+        # Setlist with multiple sets
+        %{
+          "artist" => %{"name" => "Test Artist"},
+          "eventDate" => "03-01-2023",
+          "id" => "test-id-3",
+          "venue" => %{
+            "name" => "Multi Set Venue",
+            "city" => %{
+              "name" => "Chicago",
+              "stateCode" => "IL",
+              "country" => %{"name" => "United States"}
+            }
+          },
+          "sets" => %{
+            "set" => [
+              %{
+                "name" => "Opening Set",
+                "song" => [
+                  %{"name" => "Opening Song 1"},
+                  %{"name" => "Opening Song 2"}
+                ]
+              },
+              %{
+                "name" => "Main Set",
+                "song" => [
+                  %{"name" => "Main Song 1"},
+                  %{"name" => "Main Song 2"},
+                  %{"name" => "Main Song 3"}
+                ]
+              }
+            ]
+          }
+        },
+        # Setlist with set and encore
+        %{
+          "artist" => %{"name" => "Test Artist"},
+          "eventDate" => "04-01-2023",
+          "id" => "test-id-4",
+          "venue" => %{
+            "name" => "Encore Venue",
+            "city" => %{
+              "name" => "Nashville",
+              "stateCode" => "TN",
+              "country" => %{"name" => "United States"}
+            }
+          },
+          "sets" => %{
+            "set" => [
+              %{
+                "name" => "Main Set",
+                "song" => [
+                  %{"name" => "Main Song 1"},
+                  %{"name" => "Main Song 2"},
+                  %{"name" => "Main Song 3"},
+                  %{"name" => "Main Song 4"}
+                ]
+              },
+              %{
+                "encore" => 1,
+                "song" => [
+                  %{"name" => "Encore Song 1"},
+                  %{"name" => "Encore Song 2"}
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    }
+
+    Req.Test.stub(MySetlistFmStub, fn
+      %{request_path: "/rest/1.0/search/setlists", method: "GET"} = conn ->
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(response))
+    end)
+
+    [no_songs, one_set, multiple_sets, set_with_encore] = ExternalClient.search("test artist")
+
+    # Test setlist with no songs
+    assert no_songs.song_count == 0
+    assert no_songs.venue.name == "Empty Venue"
+    assert no_songs.venue.location.city == "Austin"
+
+    # Test setlist with one set
+    assert one_set.song_count == 3
+    assert one_set.venue.name == "Single Set Venue"
+    assert one_set.venue.location.city == "Seattle"
+
+    # Test setlist with multiple sets
+    assert multiple_sets.song_count == 5
+    assert multiple_sets.venue.name == "Multi Set Venue"
+    assert multiple_sets.venue.location.city == "Chicago"
+
+    # Test setlist with set and encore
+    assert set_with_encore.song_count == 6
+    assert set_with_encore.venue.name == "Encore Venue"
+    assert set_with_encore.venue.location.city == "Nashville"
+  end
+
+  test "search/1 handles sets with missing or empty song arrays" do
+    response = %{
+      "setlist" => [
+        %{
+          "artist" => %{"name" => "Test Artist"},
+          "eventDate" => "01-01-2023",
+          "id" => "test-id-1",
+          "venue" => %{
+            "name" => "Test Venue",
+            "city" => %{
+              "name" => "Portland",
+              "stateCode" => "OR",
+              "country" => %{"name" => "United States"}
+            }
+          },
+          "sets" => %{
+            "set" => [
+              # Set with empty song array
+              %{
+                "name" => "Empty Set",
+                "song" => []
+              },
+              # Set with missing song key (no songs)
+              %{
+                "name" => "No Song Key"
+              },
+              # Set with songs
+              %{
+                "name" => "Normal Set",
+                "song" => [
+                  %{"name" => "Song 1"},
+                  %{"name" => "Song 2"}
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    }
+
+    Req.Test.stub(MySetlistFmStub, fn
+      %{request_path: "/rest/1.0/search/setlists", method: "GET"} = conn ->
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.send_resp(200, Jason.encode!(response))
+    end)
+
+    [result] = ExternalClient.search("test artist")
+
+    # Should count only the songs from the normal set
+    assert result.song_count == 2
+    assert result.venue.location.city == "Portland"
+  end
+
   @get_response fixture_dir() |> Path.join("setlist_fm_setlist_response.json") |> File.read!()
   test "get_setlist/1" do
     id = Ecto.UUID.generate()

--- a/test/setlistify/setlist_fm/api/external_client_test.exs
+++ b/test/setlistify/setlist_fm/api/external_client_test.exs
@@ -141,6 +141,9 @@ defmodule Setlistify.SetlistFm.API.ExternalClientTest do
 
     assert result.artist == "Modest Mouse"
     assert result.venue.name == "Terminal 5"
+    assert result.venue.location.city == "New York"
+    assert result.venue.location.state == "NY"
+    assert result.venue.location.country == "United States"
     assert result.date == Date.new!(2022, 12, 19)
     assert length(result.sets) == 3
     assert Enum.count(result.sets, & &1.encore) == 1

--- a/test/setlistify_web/live/search_live_test.exs
+++ b/test/setlistify_web/live/search_live_test.exs
@@ -21,9 +21,13 @@ defmodule SetlistifyWeb.SearchLiveTest do
       [
         %{
           artist: "The Beatles",
-          venue: %{name: "Compaq Center"},
+          venue: %{
+            name: "Compaq Center",
+            location: %{city: "Houston", state: "TX", country: "United States"}
+          },
           date: Date.new!(2023, 01, 01),
-          id: setlist_id
+          id: setlist_id,
+          song_count: 12
         }
       ]
     end)

--- a/test/setlistify_web/live/search_live_test.exs
+++ b/test/setlistify_web/live/search_live_test.exs
@@ -47,4 +47,48 @@ defmodule SetlistifyWeb.SearchLiveTest do
     view |> element(tid("setlist-#{setlist_id}")) |> render_click()
     assert_redirected(view, ~p"/setlist/#{setlist_id}")
   end
+
+  test "displays song count in search results", %{conn: conn} do
+    expect(SetlistFm.API.MockClient, :search, 1, fn "test artist" ->
+      [
+        %{
+          artist: "Test Artist",
+          venue: %{
+            name: "Test Venue 1",
+            location: %{city: "Austin", state: "TX", country: "United States"}
+          },
+          date: Date.new!(2023, 01, 01),
+          id: "test-id-1",
+          song_count: 0
+        },
+        %{
+          artist: "Test Artist",
+          venue: %{
+            name: "Test Venue 2",
+            location: %{city: "Seattle", state: "WA", country: "United States"}
+          },
+          date: Date.new!(2023, 01, 02),
+          id: "test-id-2",
+          song_count: 15
+        },
+        %{
+          artist: "Test Artist",
+          venue: %{
+            name: "Test Venue 3",
+            location: %{city: "Nashville", state: "TN", country: "United States"}
+          },
+          date: Date.new!(2023, 01, 03),
+          id: "test-id-3",
+          song_count: 1
+        }
+      ]
+    end)
+
+    {:ok, _view, html} = live(conn, ~p"/?query=test+artist")
+
+    # Check that song counts are displayed
+    assert html =~ "0 songs"
+    assert html =~ "15 songs"
+    assert html =~ "1 song"
+  end
 end

--- a/test/setlistify_web/live/search_live_test.exs
+++ b/test/setlistify_web/live/search_live_test.exs
@@ -41,6 +41,7 @@ defmodule SetlistifyWeb.SearchLiveTest do
 
     assert html =~ "The Beatles"
     assert html =~ "Compaq Center"
+    assert html =~ "Houston, TX, United States"
     assert html =~ "2023-01-01"
 
     view |> element(tid("setlist-#{setlist_id}")) |> render_click()

--- a/test/setlistify_web/live/setlists/show_live_test.exs
+++ b/test/setlistify_web/live/setlists/show_live_test.exs
@@ -30,7 +30,14 @@ defmodule SetlistifyWeb.Setlists.ShowLiveTest do
     expect(SetlistFm.API.MockClient, :get_setlist, 1, fn ^setlist_id ->
       %{
         artist: "The Beatles",
-        venue: %{name: "Compaq Center"},
+        venue: %{
+          name: "Compaq Center",
+          location: %{
+            city: "Houston",
+            state: "TX",
+            country: "United States"
+          }
+        },
         date: Date.new!(2023, 01, 01),
         sets: [
           %{name: "Warm up", songs: [%{title: "a warm up song"}]},
@@ -51,6 +58,33 @@ defmodule SetlistifyWeb.Setlists.ShowLiveTest do
     assert html =~ "Encore 1"
     assert html =~ "encore song1"
     assert html =~ "encore song2"
+  end
+
+  test "displays venue location when viewing a setlist", %{conn: conn} do
+    setlist_id = Ecto.UUID.generate()
+
+    expect(SetlistFm.API.MockClient, :get_setlist, 1, fn ^setlist_id ->
+      %{
+        artist: "The Beatles",
+        venue: %{
+          name: "Compaq Center",
+          location: %{
+            city: "Houston",
+            state: "TX",
+            country: "United States"
+          }
+        },
+        date: Date.new!(2023, 01, 01),
+        sets: [
+          %{name: "Main", songs: [%{title: "Hey Jude"}]}
+        ]
+      }
+    end)
+
+    {:ok, _view, html} = live(conn, ~p"/setlist/#{setlist_id}")
+
+    assert html =~ "Compaq Center"
+    assert html =~ "Houston, TX, United States"
   end
 
   test "viewing a setlist when authenticated with Spotify searches for songs", %{conn: conn} do
@@ -77,7 +111,14 @@ defmodule SetlistifyWeb.Setlists.ShowLiveTest do
     expect(SetlistFm.API.MockClient, :get_setlist, 1, fn ^setlist_id ->
       %{
         artist: artist,
-        venue: %{name: "Compaq Center"},
+        venue: %{
+          name: "Compaq Center",
+          location: %{
+            city: "Houston",
+            state: "TX",
+            country: "United States"
+          }
+        },
         date: Date.utc_today(),
         sets: [%{name: nil, songs: [%{title: "song1"}, %{title: "song2"}]}]
       }
@@ -132,7 +173,14 @@ defmodule SetlistifyWeb.Setlists.ShowLiveTest do
     expect(SetlistFm.API.MockClient, :get_setlist, 1, fn ^setlist_id ->
       %{
         artist: artist,
-        venue: %{name: venue},
+        venue: %{
+          name: venue,
+          location: %{
+            city: "Houston",
+            state: "TX",
+            country: "United States"
+          }
+        },
         date: Date.utc_today(),
         sets: [%{name: nil, songs: [%{title: "song1"}, %{title: "song2"}]}]
       }


### PR DESCRIPTION
## Summary
- Add total song count display to setlist search results
- Display venue location information (city, state, country) in search results and setlist views
- Use gettext for proper pluralization of song counts

## Changes
- Updated API types to include song count and location data
- Modified search results view to show song count next to artist name
- Added venue location display to both search results and setlist show pages
- Implemented proper error handling for missing venue data
- Added comprehensive test coverage for all scenarios

## Implementation Details
- Song counts are calculated by counting all songs across all sets in a setlist
- Venue locations display city, state (when available), and country
- Pluralization uses gettext's `ngettext` function for internationalization
- Added tests for edge cases (empty sets, missing location data, etc.)

## Test plan
- [x] All existing tests pass
- [x] Added new tests for song count calculations
- [x] Added tests for location display in views
- [x] Tested edge cases (no songs, missing venue data)

🤖 Generated with [Claude Code](https://claude.ai/code)