### PR TITLE
refactor: remove deprecated refresh_token function

### DIFF
--- a/lib/setlistify/spotify/session_manager.ex
+++ b/lib/setlistify/spotify/session_manager.ex
@@ -112,14 +112,6 @@ defmodule Setlistify.Spotify.SessionManager do
     end
   end
 
-  @deprecated "Use refresh_session/1 instead"
-  def refresh_token(user_id) do
-    case lookup(user_id) do
-      {:ok, pid} -> GenServer.call(pid, :refresh_token)
-      :error -> {:error, :not_found}
-    end
-  end
-
   @doc """
   Refreshes the token for a specific user and returns the updated UserSession.
   """
@@ -157,19 +149,6 @@ defmodule Setlistify.Spotify.SessionManager do
     {:ok, state, {:continue, :schedule_refresh}}
   end
 
-  @deprecated "Use UserSession struct instead of map in init/1"
-  def init(
-        {user_id, %{access_token: _, refresh_token: _, expires_in: expires_in} = initial_tokens}
-      ) do
-    # Handle deprecated map format - convert to state structure
-    state =
-      initial_tokens
-      |> Map.put(:user_id, user_id)
-      |> Map.put(:expires_at, timestamp() + expires_in)
-
-    {:ok, state, {:continue, :schedule_refresh}}
-  end
-
   @impl true
   def handle_continue(:schedule_refresh, state = %{expires_at: expires_at}) do
     schedule_refresh(expires_at - timestamp() - @refresh_threshold)
@@ -194,17 +173,6 @@ defmodule Setlistify.Spotify.SessionManager do
     }
 
     {:reply, {:ok, session}, state}
-  end
-
-  @impl true
-  def handle_call(:refresh_token, _from, state) do
-    case do_refresh_token(state) do
-      {:ok, new_state, new_tokens} ->
-        {:reply, {:ok, new_tokens.access_token}, new_state}
-
-      {:error, _reason} = error ->
-        {:stop, :normal, error, state}
-    end
   end
 
   @impl true

--- a/test/setlistify/spotify/session_manager_test.exs
+++ b/test/setlistify/spotify/session_manager_test.exs
@@ -128,53 +128,6 @@ defmodule Setlistify.Spotify.SessionManagerTest do
     end
   end
 
-  describe "refresh_token/1" do
-    @moduledoc """
-    Tests for the deprecated refresh_token/1 function.
-    These tests ensure backward compatibility while the function is still available.
-    """
-
-    @tag :deprecated
-    test "refreshes token successfully", %{user_id: user_id, initial_token: initial_token} do
-      {:ok, pid} = SessionManager.start_link({user_id, initial_token})
-      new_token = "new_access_token"
-
-      expect(Setlistify.Spotify.API.MockClient, :refresh_token, fn refresh_token ->
-        assert refresh_token == initial_token.refresh_token
-
-        {:ok,
-         %{
-           access_token: new_token,
-           refresh_token: refresh_token,
-           expires_in: 3600
-         }}
-      end)
-
-      allow(Setlistify.Spotify.API.MockClient, self(), pid)
-
-      assert {:ok, ^new_token} = SessionManager.refresh_token(user_id)
-    end
-
-    @tag :capture_log
-    @tag :deprecated
-    test "terminates process on refresh failure", %{
-      user_id: user_id,
-      initial_token: initial_token
-    } do
-      {:ok, pid} = SessionManager.start_link({user_id, initial_token})
-
-      expect(Setlistify.Spotify.API.MockClient, :refresh_token, fn refresh_token ->
-        assert refresh_token == initial_token.refresh_token
-        {:error, :invalid_token}
-      end)
-
-      allow(Setlistify.Spotify.API.MockClient, self(), pid)
-
-      assert {:error, :invalid_token} = SessionManager.refresh_token(user_id)
-      refute Process.alive?(pid)
-    end
-  end
-
   describe "refresh_session/1" do
     test "refreshes token and returns UserSession", %{
       user_id: user_id,

--- a/test/setlistify_web/controllers/oauth_callback_controller_test.exs
+++ b/test/setlistify_web/controllers/oauth_callback_controller_test.exs
@@ -110,8 +110,16 @@ defmodule SetlistifyWeb.OAuthCallbackControllerTest do
 
       # Start a session process using the supervisor to properly register it
       assert Registry.lookup(Setlistify.UserSessionRegistry, test_user) == []
-      tokens = %{access_token: "test", refresh_token: "test", expires_in: 3600}
-      {:ok, original_pid} = SessionSupervisor.start_user_token(test_user, tokens)
+
+      user_session = %Setlistify.Spotify.UserSession{
+        access_token: "test",
+        refresh_token: "test",
+        expires_at: System.system_time(:second) + 3600,
+        user_id: test_user,
+        username: "test_user"
+      }
+
+      {:ok, original_pid} = SessionSupervisor.start_user_token(test_user, user_session)
       assert Process.alive?(original_pid)
 
       # Verify process is registered with the Registry


### PR DESCRIPTION
## Summary
- Remove deprecated `refresh_token/1` function and its tests - replaced by `refresh_session/1`
- Remove deprecated map-based `init/1` - replaced by UserSession struct initialization
- Update test that was using deprecated map format to use UserSession struct

## Test plan
- [x] Run all tests with `mix test` - all tests pass
- [x] Run code formatter with `mix format`
- [x] Review code changes to ensure only deprecated functions were removed
- [x] No functional changes, only cleanup of technical debt

🤖 Generated with [Claude Code](https://claude.ai/code)