### PR TITLE
build: remove Ecto references from formatter configuration

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,6 +1,5 @@
 [
-  import_deps: [:ecto, :phoenix],
-  subdirectories: ["priv/*/migrations"],
+  import_deps: [:phoenix],
   plugins: [Phoenix.LiveView.HTMLFormatter],
-  inputs: ["*.{heex,ex,exs}", "{config,lib,test}/**/*.{heex,ex,exs}", "priv/*/seeds.exs"]
+  inputs: ["*.{heex,ex,exs}", "{config,lib,test}/**/*.{heex,ex,exs}"]
 ]


### PR DESCRIPTION
## Summary
- Removed Ecto-related configuration from `.formatter.exs` since we're not using Ecto in this project

## Test plan
- [x] Run `mix format` - passes without errors
- [x] Run `mix test` - all 103 tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)