### PR TITLE
Remove unused Ecto/database metrics

### DIFF
--- a/lib/setlistify_web/telemetry.ex
+++ b/lib/setlistify_web/telemetry.ex
@@ -51,29 +51,6 @@ defmodule SetlistifyWeb.Telemetry do
         unit: {:native, :millisecond}
       ),
 
-      # Database Metrics
-      summary("setlistify.repo.query.total_time",
-        unit: {:native, :millisecond},
-        description: "The sum of the other measurements"
-      ),
-      summary("setlistify.repo.query.decode_time",
-        unit: {:native, :millisecond},
-        description: "The time spent decoding the data received from the database"
-      ),
-      summary("setlistify.repo.query.query_time",
-        unit: {:native, :millisecond},
-        description: "The time spent executing the query"
-      ),
-      summary("setlistify.repo.query.queue_time",
-        unit: {:native, :millisecond},
-        description: "The time spent waiting for a database connection"
-      ),
-      summary("setlistify.repo.query.idle_time",
-        unit: {:native, :millisecond},
-        description:
-          "The time the connection spent waiting before being checked out for the query"
-      ),
-
       # VM Metrics
       summary("vm.memory.total", unit: {:byte, :kilobyte}),
       summary("vm.total_run_queue_lengths.total"),


### PR DESCRIPTION
## Summary
- Remove all database-related telemetry metrics since this application doesn't use Ecto or a database
- Clean up telemetry configuration by removing unnecessary repo query metrics

## Test plan
- [ ] Verify telemetry still works correctly without database metrics
- [ ] Check that application starts without errors
- [ ] Confirm no references to removed metrics remain in codebase

🤖 Generated with [Claude Code](https://claude.ai/code)