### PR TITLE
feat(o11y): configure Grafana Cloud Loki for centralized logging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,10 +84,11 @@ Required environment variables:
 - `SPOTIFY_CLIENT_SECRET` - OAuth client secret for Spotify
 
 Optional environment variables for Grafana Cloud observability:
-- `GRAFANA_CLOUD_API_KEY` - API key for Grafana Cloud
-- `GRAFANA_CLOUD_USER_ID` - User ID from Grafana Cloud
+- `GRAFANA_CLOUD_API_KEY` - API key for Grafana Cloud (shared for all services)
+- `GRAFANA_CLOUD_USER_ID` - User ID for Tempo from Grafana Cloud
 - `GRAFANA_CLOUD_TEMPO_ENDPOINT` - Tempo endpoint for traces
-- `GRAFANA_CLOUD_LOKI_ENDPOINT` - Loki endpoint for logs
+- `GRAFANA_CLOUD_LOKI_ENDPOINT` - Loki endpoint for logs (must include /loki/api/v1/push)
+- `GRAFANA_CLOUD_LOKI_USER_ID` - User ID for Loki (usually different from Tempo)
 - `GRAFANA_CLOUD_REGION` - Cloud region (defaults to "us-central1")
 - `GRAFANA_CLOUD_ZONE` - Cloud zone (optional)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,14 @@ Required environment variables:
 - `SPOTIFY_CLIENT_ID` - OAuth client ID for Spotify
 - `SPOTIFY_CLIENT_SECRET` - OAuth client secret for Spotify
 
+Optional environment variables for Grafana Cloud observability:
+- `GRAFANA_CLOUD_API_KEY` - API key for Grafana Cloud
+- `GRAFANA_CLOUD_USER_ID` - User ID from Grafana Cloud
+- `GRAFANA_CLOUD_TEMPO_ENDPOINT` - Tempo endpoint for traces
+- `GRAFANA_CLOUD_LOKI_ENDPOINT` - Loki endpoint for logs
+- `GRAFANA_CLOUD_REGION` - Cloud region (defaults to "us-central1")
+- `GRAFANA_CLOUD_ZONE` - Cloud zone (optional)
+
 These values are automatically loaded from `.env` in development. You can copy `.env.example` to `.env` and fill in the values.
 
 ## Development Reminders

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -73,4 +73,3 @@ config :phoenix, :stacktrace_depth, 20
 config :phoenix, :plug_init_mode, :runtime
 
 config :phoenix_live_view, debug_heex_annotations: true
-

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -74,13 +74,3 @@ config :phoenix, :plug_init_mode, :runtime
 
 config :phoenix_live_view, debug_heex_annotations: true
 
-# Loki logger backend configuration
-config :logger, Setlistify.LokiLogger,
-  url: "http://localhost:3100/loki/api/v1/push",
-  level: :info,
-  metadata: [:request_id, :trace_id, :span_id, :user_id],
-  max_buffer: 50,
-  labels: %{
-    "application" => "setlistify",
-    "environment" => "development"
-  }

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -79,25 +79,6 @@ if config_env() == :prod do
   #       force_ssl: [hsts: true]
   #
   # Check `Plug.SSL` for all available options in `force_ssl`.
-
-  # Grafana Cloud Loki configuration for production
-  if loki_url = System.get_env("LOKI_URL") do
-    config :logger,
-      backends: [:console, Setlistify.LokiLogger]
-
-    config :logger, Setlistify.LokiLogger,
-      url: loki_url,
-      username: System.get_env("LOKI_USERNAME"),
-      password: System.get_env("LOKI_PASSWORD"),
-      level: :info,
-      metadata: [:request_id, :trace_id, :span_id, :user_id],
-      max_buffer: 100,
-      labels: %{
-        "application" => "setlistify",
-        "environment" => "production",
-        "instance" => System.get_env("FLY_ALLOC_ID", "unknown")
-      }
-  end
 end
 
 # Non-prod specific configuration
@@ -176,6 +157,29 @@ if use_grafana_cloud do
         provider: "grafana",
         region: grafana_region
       ] ++ zone_attrs
+
+  # Configure Loki logging for Grafana Cloud
+  loki_endpoint = System.get_env("GRAFANA_CLOUD_LOKI_ENDPOINT")
+
+  if loki_endpoint do
+    config :logger,
+      backends: [:console, Setlistify.LokiLogger]
+
+    config :logger, Setlistify.LokiLogger,
+      url: loki_endpoint,
+      username: grafana_user_id,
+      password: grafana_api_key,
+      level: :info,
+      metadata: [:request_id, :trace_id, :span_id, :user_id],
+      max_buffer: 100,
+      labels: %{
+        "application" => "setlistify",
+        "environment" => config_env() |> to_string(),
+        "instance" => System.get_env("FLY_ALLOC_ID", "unknown"),
+        "fly_app" => System.get_env("FLY_APP_NAME", "setlistify"),
+        "fly_region" => System.get_env("FLY_REGION", "unknown")
+      }
+  end
 else
   # Local OTEL-LGTM configuration (default)
   config :opentelemetry_exporter,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -221,13 +221,10 @@ if use_grafana_cloud do
 
   # Logs / Loki
   loki_endpoint = System.get_env("GRAFANA_CLOUD_LOKI_ENDPOINT")
+  loki_user_id = System.get_env("GRAFANA_CLOUD_LOKI_USER_ID")
 
-  if loki_endpoint do
-    # Loki may use different credentials than Tempo
-    loki_user_id = System.get_env("GRAFANA_CLOUD_LOKI_USER_ID")
-
-    config :logger,
-      backends: [:console, Setlistify.LokiLogger]
+  if loki_endpoint && loki_user_id do
+    config :logger, backends: [:console, Setlistify.LokiLogger]
 
     config :logger, Setlistify.LokiLogger,
       url: loki_endpoint,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -169,13 +169,17 @@ if use_grafana_cloud do
   loki_endpoint = System.get_env("GRAFANA_CLOUD_LOKI_ENDPOINT")
 
   if loki_endpoint do
+    # Loki may use different credentials than Tempo
+    loki_user_id = System.get_env("GRAFANA_CLOUD_LOKI_USER_ID") || grafana_user_id
+    loki_api_key = System.get_env("GRAFANA_CLOUD_LOKI_API_KEY") || grafana_api_key
+
     config :logger,
       backends: [:console, Setlistify.LokiLogger]
 
     config :logger, Setlistify.LokiLogger,
       url: loki_endpoint,
-      username: grafana_user_id,
-      password: grafana_api_key,
+      username: loki_user_id,
+      password: loki_api_key,
       level: :info,
       metadata: [:request_id, :trace_id, :span_id, :user_id],
       max_buffer: 100,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -238,7 +238,7 @@ if use_grafana_cloud do
       max_buffer: 100,
       labels: %{
         "application" => "setlistify",
-        "environment" => config_env() |> to_string(),
+        "environment" => config_env(),
         "instance" => System.get_env("FLY_ALLOC_ID", "unknown"),
         "fly_app" => System.get_env("FLY_APP_NAME", "setlistify"),
         "fly_region" => System.get_env("FLY_REGION", "unknown")

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -224,8 +224,7 @@ if use_grafana_cloud do
 
   if loki_endpoint do
     # Loki may use different credentials than Tempo
-    loki_user_id = System.get_env("GRAFANA_CLOUD_LOKI_USER_ID") || grafana_user_id
-    loki_api_key = System.get_env("GRAFANA_CLOUD_LOKI_API_KEY") || grafana_api_key
+    loki_user_id = System.get_env("GRAFANA_CLOUD_LOKI_USER_ID")
 
     config :logger,
       backends: [:console, Setlistify.LokiLogger]
@@ -233,7 +232,7 @@ if use_grafana_cloud do
     config :logger, Setlistify.LokiLogger,
       url: loki_endpoint,
       username: loki_user_id,
-      password: loki_api_key,
+      password: grafana_api_key,
       level: :info,
       metadata: [:request_id, :trace_id, :span_id, :user_id],
       max_buffer: 100,
@@ -245,7 +244,8 @@ if use_grafana_cloud do
         "fly_region" => System.get_env("FLY_REGION", "unknown")
       }
   end
-# Local OTEL-LGTM configuration (default)
+
+  # Local OTEL-LGTM configuration (default)
 else
   # OpenTelemetry / Tempo
   config :opentelemetry_exporter,
@@ -281,4 +281,15 @@ else
       port: String.to_integer(System.get_env("PROM_EX_PORT", "9568")),
       path: "/metrics"
     ]
+
+  # Local Loki configuration
+  config :logger, Setlistify.LokiLogger,
+    url: "http://localhost:3100/loki/api/v1/push",
+    level: :info,
+    metadata: [:request_id, :trace_id, :span_id, :user_id],
+    max_buffer: 50,
+    labels: %{
+      "application" => "setlistify",
+      "environment" => "development"
+    }
 end

--- a/docs/grafana-cloud-setup-working.md
+++ b/docs/grafana-cloud-setup-working.md
@@ -7,12 +7,22 @@ This configuration is based on the working example from [Silbernagel.dev](https:
 ```bash
 # Required
 export GRAFANA_CLOUD_API_KEY="your-api-key-here"
-export GRAFANA_CLOUD_USER_ID="1219955"  # Your Tempo user ID from Grafana Cloud
+export GRAFANA_CLOUD_USER_ID="1219955"  # Your user ID from Grafana Cloud
 export GRAFANA_CLOUD_REGION="us-east-2"  # Your region
+
+# Tempo (Traces) - Working
+export GRAFANA_CLOUD_TEMPO_ENDPOINT="https://tempo-prod-26-prod-us-east-2.grafana.net/tempo"
+
+# Loki (Logs) - New
+export GRAFANA_CLOUD_LOKI_ENDPOINT="https://logs-prod-012.grafana.net/loki/api/v1/push"
 
 # Optional
 export GRAFANA_CLOUD_ZONE="prod-us-east-0"
 ```
+
+**Important**: Find your specific endpoints in your Grafana Cloud portal:
+- For Tempo: Look in the Tempo data source configuration
+- For Loki: Look in the Loki data source configuration or "Details" page
 
 ## Configuration (config/runtime.exs)
 
@@ -88,14 +98,46 @@ else
 end
 ```
 
+## Loki Configuration (Logs)
+
+The Loki configuration is added alongside the Tempo configuration:
+
+```elixir
+# Configure Loki logging for Grafana Cloud
+loki_endpoint = System.get_env("GRAFANA_CLOUD_LOKI_ENDPOINT")
+
+if loki_endpoint do
+  config :logger,
+    backends: [:console, Setlistify.LokiLogger]
+
+  config :logger, Setlistify.LokiLogger,
+    url: loki_endpoint,
+    username: grafana_user_id,
+    password: grafana_api_key,
+    level: :info,
+    metadata: [:request_id, :trace_id, :span_id, :user_id],
+    max_buffer: 100,
+    labels: %{
+      "application" => "setlistify",
+      "environment" => config_env() |> to_string(),
+      "instance" => System.get_env("FLY_ALLOC_ID", "unknown"),
+      "fly_app" => System.get_env("FLY_APP_NAME", "setlistify"),
+      "fly_region" => System.get_env("FLY_REGION", "unknown")
+    }
+end
+```
+
 ## Key Differences from Previous Attempts
 
 1. **Use `otlp_traces_endpoint` not `otlp_endpoint`** - This is crucial!
 2. **Include `/tempo` in the endpoint URL** for Grafana Cloud
 3. **Use the full HTTPS URL** for gRPC protocol
 4. **Authorization header format**: `"Basic #{otel_auth}"` not `"Basic " <> otel_auth`
+5. **Loki uses the same authentication** as Tempo (user_id and API key)
 
 ## Testing
+
+### Testing Traces (Tempo)
 
 1. Start your application:
    ```bash
@@ -120,11 +162,49 @@ end
    - Search for traces
    - Try an empty query `{}` first to see all traces
 
+### Testing Logs (Loki)
+
+1. Generate test logs in IEx:
+   ```elixir
+   require Logger
+   
+   # Generate a log with trace context
+   OpenTelemetry.Tracer.with_span "test.loki_logging" do
+     Logger.info("Test log from Grafana Cloud integration")
+     Logger.error("Test error log with trace context")
+   end
+   
+   # Force flush the logger
+   :gen_event.sync_notify(Logger, :flush)
+   ```
+
+2. Check Grafana Cloud:
+   - Go to https://setlistify.grafana.net/explore
+   - Select your Loki data source
+   - Try queries like:
+     - `{application="setlistify"}`
+     - `{application="setlistify", level="error"}`
+     - `{application="setlistify"} |= "test"`
+
 ## Troubleshooting
 
-If traces don't appear:
+### If traces don't appear:
 
 1. Check the logs for "OTLP exporter successfully initialized"
 2. Verify environment variables are loaded (check with `System.get_env/1` in IEx)
 3. Make sure you're using the Tempo user ID, not the instance ID
 4. Check that the region in your endpoint matches your Grafana Cloud setup
+
+### If logs don't appear:
+
+1. Check for any stderr output from LokiLogger: `[LokiLogger] Failed to send logs`
+2. Verify the Loki endpoint includes `/loki/api/v1/push`
+3. Test authentication with curl:
+   ```bash
+   curl -v -H "Content-Type: application/json" \
+     -u "$GRAFANA_CLOUD_USER_ID:$GRAFANA_CLOUD_API_KEY" \
+     -X POST "$GRAFANA_CLOUD_LOKI_ENDPOINT" \
+     -d '{"streams": [{"stream": {"application": "test"}, "values": [["1234567890000000000", "test log"]]}]}'
+   ```
+4. Make sure timestamps are strings (nanoseconds)
+5. Check that your labels don't contain invalid characters

--- a/docs/grafana-cloud-setup-working.md
+++ b/docs/grafana-cloud-setup-working.md
@@ -7,14 +7,15 @@ This configuration is based on the working example from [Silbernagel.dev](https:
 ```bash
 # Required
 export GRAFANA_CLOUD_API_KEY="your-api-key-here"
-export GRAFANA_CLOUD_USER_ID="1219955"  # Your user ID from Grafana Cloud
+export GRAFANA_CLOUD_USER_ID="1219955"  # Your Tempo user ID from Grafana Cloud
 export GRAFANA_CLOUD_REGION="us-east-2"  # Your region
 
 # Tempo (Traces) - Working
 export GRAFANA_CLOUD_TEMPO_ENDPOINT="https://tempo-prod-26-prod-us-east-2.grafana.net/tempo"
 
-# Loki (Logs) - New
+# Loki (Logs) - Working
 export GRAFANA_CLOUD_LOKI_ENDPOINT="https://logs-prod-012.grafana.net/loki/api/v1/push"
+export GRAFANA_CLOUD_LOKI_USER_ID="1225644"  # Different from Tempo! Check Loki Details page
 
 # Optional
 export GRAFANA_CLOUD_ZONE="prod-us-east-0"
@@ -133,7 +134,8 @@ end
 2. **Include `/tempo` in the endpoint URL** for Grafana Cloud
 3. **Use the full HTTPS URL** for gRPC protocol
 4. **Authorization header format**: `"Basic #{otel_auth}"` not `"Basic " <> otel_auth`
-5. **Loki uses the same authentication** as Tempo (user_id and API key)
+5. **Loki requires its own user ID** - Found in Grafana Cloud > Loki > Details
+6. **Loki endpoint must include full path**: `/loki/api/v1/push`
 
 ## Testing
 

--- a/docs/opentelemetry-implementation-tech-spec.md
+++ b/docs/opentelemetry-implementation-tech-spec.md
@@ -8,9 +8,12 @@ This document outlines the implementation of OpenTelemetry in Setlistify, our El
 - Phase 0 completed (local development stack)
 - Phase 1 in progress (Direct OpenTelemetry instrumentation implemented for Spotify API)
 - Phase 2 partially completed (trace context in logs)
-- **Grafana Cloud Integration:** Traces are successfully configured and sending to Grafana Cloud Tempo. Logs (Loki) and metrics (Prometheus) integration still pending.
+- **Grafana Cloud Integration:** 
+  - ✅ Traces (Tempo) - Successfully configured and working
+  - ✅ Logs (Loki) - Successfully configured with LokiLogger backend
+  - ❌ Metrics (Prometheus/Mimir) - Still pending
 
-**Last Updated:** May 27, 2025
+**Last Updated:** May 28, 2025
 
 ## Background
 
@@ -322,24 +325,39 @@ if use_grafana_cloud do
 end
 ```
 
-**Future Configuration Needed (Logs and Metrics):**
+**Loki Configuration (IMPLEMENTED):**
 
 ```elixir
-# Loki configuration for logs (NOT YET IMPLEMENTED)
-if loki_url = System.get_env("LOKI_URL") do
+# Configure Loki logging for Grafana Cloud
+loki_endpoint = System.get_env("GRAFANA_CLOUD_LOKI_ENDPOINT")
+
+if loki_endpoint do
   config :logger,
     backends: [:console, Setlistify.LokiLogger]
 
   config :logger, Setlistify.LokiLogger,
-    url: loki_url,
-    username: System.get_env("LOKI_USERNAME"),
-    password: System.get_env("LOKI_PASSWORD"),
+    url: loki_endpoint,
+    username: grafana_user_id,
+    password: grafana_api_key,
     level: :info,
-    metadata: [:request_id, :trace_id, :span_id, :user_id]
+    metadata: [:request_id, :trace_id, :span_id, :user_id],
+    max_buffer: 100,
+    labels: %{
+      "application" => "setlistify",
+      "environment" => config_env() |> to_string(),
+      "instance" => System.get_env("FLY_ALLOC_ID", "unknown"),
+      "fly_app" => System.get_env("FLY_APP_NAME", "setlistify"),
+      "fly_region" => System.get_env("FLY_REGION", "unknown")
+    }
 end
+```
 
+**Future Configuration Needed (Metrics Only):**
+
+```elixir
 # Prometheus/Mimir configuration for metrics (NOT YET IMPLEMENTED)
 # This will require additional setup with PromEx or similar
+# Expected to use a similar pattern with GRAFANA_CLOUD_PROMETHEUS_ENDPOINT
 ```
 
 ### 3. Local Development Stack
@@ -1112,19 +1130,24 @@ The current `:telemetry.span/3` approach provides explicit, flexible instrumenta
 2. ✅ Update production configuration for Tempo (traces) endpoint
 3. ✅ Configure environment variables for Grafana Cloud
 4. ✅ Successfully deployed and validated trace data flow to Grafana Cloud Tempo
+5. ✅ Configure Loki for cloud logging with LokiLogger backend
+6. ✅ Add GRAFANA_CLOUD_LOKI_ENDPOINT environment variable support
+7. ✅ Update documentation with Loki configuration details
 
 **Tasks Remaining:**
-1. Configure Loki for cloud logging (separate from traces)
-2. Configure Prometheus/Mimir for metrics collection (separate from traces)
-3. Configure Fly.io secrets for production deployment
-4. Import dashboards and configure cloud alerts
-5. Monitor costs and optimize for free tier limits
-6. Update documentation for complete production setup
+1. Configure Prometheus/Mimir for metrics collection (separate from traces and logs)
+2. Configure Fly.io secrets for production deployment (including LOKI_ENDPOINT)
+3. Import dashboards and configure cloud alerts
+4. Monitor costs and optimize for free tier limits
+5. Create correlation queries between traces and logs in Grafana
 
 **Notes:**
-- Traces are successfully sending to Grafana Cloud Tempo using the configuration from Silbernagel.dev blog
-- Logs and metrics require separate configuration as they use different endpoints and authentication
-- Each telemetry signal (traces, logs, metrics) has its own endpoint and configuration in Grafana Cloud
+- Traces and logs are now both successfully configured for Grafana Cloud
+- Using the same authentication (user_id and API key) for both Tempo and Loki
+- Each telemetry signal has its own endpoint:
+  - Traces: `GRAFANA_CLOUD_TEMPO_ENDPOINT` (e.g., `https://tempo-prod-26-prod-us-east-2.grafana.net/tempo`)
+  - Logs: `GRAFANA_CLOUD_LOKI_ENDPOINT` (e.g., `https://logs-prod-012.grafana.net/loki/api/v1/push`)
+  - Metrics: TBD (will be Prometheus/Mimir endpoint)
 
 **Expected Timeline:** 2-3 days for remaining tasks
 **Dependencies:** Phase 4 completion for full observability
@@ -1352,4 +1375,7 @@ Create:
 - **Phase 0**: ✅ Complete - Local development stack operational
 - **Phase 1**: 🚧 In Progress - Direct OpenTelemetry instrumentation (Spotify API complete, others pending)
 - **Phase 2**: ✅ Partial - Trace context in logs, LiveView spans working
-- **Phase 5**: ✅ Partial - Grafana Cloud integration for traces only (logs and metrics pending)
+- **Phase 5**: ✅ Partial - Grafana Cloud integration for traces and logs (metrics pending)
+  - Traces (Tempo): ✅ Working
+  - Logs (Loki): ✅ Working with trace correlation
+  - Metrics (Prometheus/Mimir): ❌ Not implemented


### PR DESCRIPTION
## Summary

This PR configures Grafana Cloud Loki integration to send application logs to our centralized logging infrastructure. This builds on our existing Grafana Cloud setup for traces (Tempo) and extends it to include logs with trace correlation.

## ✅ UPDATE: Successfully Tested and Working\!

The Loki integration has been successfully tested and is now working correctly after fixing the authentication configuration.

## Changes

- Added `GRAFANA_CLOUD_LOKI_ENDPOINT` environment variable support in `config/runtime.exs`
- Configured the existing `LokiLogger` backend to send logs to Grafana Cloud
- Added support for Loki-specific user ID (different from Tempo user ID)
- Includes trace correlation metadata (`trace_id`, `span_id`) for log-to-trace correlation
- Added Fly.io specific labels for better log filtering in production

## Key Learnings

1. **Loki requires its own user ID** - Different from Tempo\! Find it in Grafana Cloud > Loki > Details
2. **Loki endpoint must include full path**: `/loki/api/v1/push`
3. **Authentication**: Loki can share the same API key as Tempo but needs its own user ID

## Required Environment Variables

### For Traces (Tempo) - Already Working
```bash
GRAFANA_CLOUD_API_KEY="glc_..."              # Your Grafana Cloud API key
GRAFANA_CLOUD_USER_ID="1219955"              # Tempo user ID
GRAFANA_CLOUD_TEMPO_ENDPOINT="https://tempo-prod-26-prod-us-east-2.grafana.net/tempo"
```

### For Logs (Loki) - New in this PR
```bash
GRAFANA_CLOUD_LOKI_ENDPOINT="https://logs-prod-036.grafana.net/loki/api/v1/push"
GRAFANA_CLOUD_LOKI_USER_ID="1225644"         # Different from Tempo\! Check Loki Details page
```

### Optional
```bash
GRAFANA_CLOUD_REGION="us-east-2"             # Your region
GRAFANA_CLOUD_ZONE="prod-us-east-0"          # Your zone
```

## How It Works

### Development Environment
- **Without .env**: Logs go to local Loki (docker-compose)
- **With .env**: Traces go to Grafana Cloud, logs still go to local Loki
- **Override**: Set `GRAFANA_CLOUD_LOKI_ENDPOINT` to send logs to cloud in dev

### Production Environment
- When `GRAFANA_CLOUD_API_KEY` is set:
  - Traces automatically go to Grafana Cloud Tempo
  - Logs go to Grafana Cloud Loki (if `GRAFANA_CLOUD_LOKI_ENDPOINT` is set)
- Includes Fly.io metadata (instance ID, region, app name)

## Deployment to Fly.io

1. **Set the required secrets**:
   ```bash
   # API key (shared for all services)
   fly secrets set GRAFANA_CLOUD_API_KEY="glc_your_api_key_here"
   
   # Tempo configuration (traces)
   fly secrets set GRAFANA_CLOUD_USER_ID="1219955"
   fly secrets set GRAFANA_CLOUD_TEMPO_ENDPOINT="https://tempo-prod-26-prod-us-east-2.grafana.net/tempo"
   
   # Loki configuration (logs)
   fly secrets set GRAFANA_CLOUD_LOKI_ENDPOINT="https://logs-prod-036.grafana.net/loki/api/v1/push"
   fly secrets set GRAFANA_CLOUD_LOKI_USER_ID="1225644"
   
   # Optional
   fly secrets set GRAFANA_CLOUD_REGION="us-east-2"
   ```

2. **Deploy the application**:
   ```bash
   fly deploy
   ```

3. **Verify in Grafana Cloud**:
   - Go to your Grafana instance
   - Navigate to Explore
   - Select Loki data source
   - Query: `{application="setlistify"}`
   - For production: `{fly_app="setlistify"}`

## Testing Performed

- [x] Local development with docker-compose Loki
- [x] Authentication with Grafana Cloud Loki
- [x] Log delivery to Grafana Cloud
- [x] Trace correlation (trace_id and span_id in logs)
- [x] Proper buffering and batching

## Verification Queries

Once deployed, you can verify logs with these queries in Grafana:

```logql
# All application logs
{application="setlistify"}

# Logs from specific Fly.io region
{application="setlistify", fly_region="iad"}

# Error logs only
{application="setlistify", level="error"}

# Logs with specific trace ID (for correlation)
{application="setlistify"} |= "trace_id=your-trace-id"
```

## Related Documentation

- [Grafana Cloud Setup Documentation](docs/grafana-cloud-setup-working.md) - Updated with Loki configuration
- [OpenTelemetry Tech Spec](docs/opentelemetry-implementation-tech-spec.md) - Updated status to reflect Loki implementation

🤖 Generated with [Claude Code](https://claude.ai/code)