### PR TITLE
Fix 404 errors when searching returns no results from Setlist.fm

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -263,21 +263,23 @@ else
       name: System.get_env("HOSTNAME", "localhost")
     ]
 
-  # Local PromEx configuration
-  config :setlistify, Setlistify.PromEx,
-    manual_metrics_start_delay: :no_delay,
-    drop_metrics_groups: [],
-    grafana: [
-      host: "http://localhost:3000",
-      auth_token: "admin:admin",
-      upload_dashboards_on_start: true,
-      folder_name: "Setlistify Dashboards",
-      annotate_app_lifecycle: true
-    ],
-    metrics_server: [
-      port: String.to_integer(System.get_env("PROM_EX_PORT", "9568")),
-      path: "/metrics"
-    ]
+  # Local PromEx configuration (skip for test environment)
+  if config_env() != :test do
+    config :setlistify, Setlistify.PromEx,
+      manual_metrics_start_delay: :no_delay,
+      drop_metrics_groups: [],
+      grafana: [
+        host: "http://localhost:3000",
+        auth_token: "admin:admin",
+        upload_dashboards_on_start: true,
+        folder_name: "Setlistify Dashboards",
+        annotate_app_lifecycle: true
+      ],
+      metrics_server: [
+        port: String.to_integer(System.get_env("PROM_EX_PORT", "9568")),
+        path: "/metrics"
+      ]
+  end
 
   # Local Loki configuration
   config :logger, Setlistify.LokiLogger,

--- a/config/test.exs
+++ b/config/test.exs
@@ -28,10 +28,7 @@ config :setlistify,
 config :opentelemetry,
   traces_exporter: :none
 
-# Configure PromEx for tests with a different port to avoid conflicts
+# Disable PromEx for tests
 config :setlistify, Setlistify.PromEx,
   grafana: :disabled,
-  metrics_server: [
-    port: 9590,
-    path: "/metrics"
-  ]
+  metrics_server: :disabled

--- a/lib/setlistify/setlist_fm/api/external_client.ex
+++ b/lib/setlistify/setlist_fm/api/external_client.ex
@@ -8,9 +8,6 @@ defmodule Setlistify.SetlistFm.API.ExternalClient do
       Req.get!(request(endpoint), url: "/search/setlists", params: %{"artistName" => query})
 
     case response do
-      %{status: 404} ->
-        []
-
       %{status: 200, body: %{"setlist" => setlists}} ->
         Enum.map(setlists, fn setlist ->
           %{
@@ -39,6 +36,10 @@ defmodule Setlistify.SetlistFm.API.ExternalClient do
             song_count: song_count
           }
         end)
+
+      # A 404 is returned when no matching results are found
+      %{status: 404} ->
+        []
     end
   end
 

--- a/lib/setlistify/setlist_fm/api/external_client.ex
+++ b/lib/setlistify/setlist_fm/api/external_client.ex
@@ -4,36 +4,42 @@ defmodule Setlistify.SetlistFm.API.ExternalClient do
   @root_endpoint "https://api.setlist.fm/rest/1.0"
 
   def search(query, endpoint \\ @root_endpoint) do
-    %{"setlist" => setlists} =
-      Req.get!(request(endpoint), url: "/search/setlists", params: %{"artistName" => query}).body
+    response =
+      Req.get!(request(endpoint), url: "/search/setlists", params: %{"artistName" => query})
 
-    Enum.map(setlists, fn setlist ->
-      %{
-        "artist" => %{"name" => artist_name},
-        "eventDate" => date,
-        "id" => id,
-        "venue" => %{
-          "name" => venue_name,
-          "city" => city_data
-        },
-        "sets" => %{"set" => sets}
-      } = setlist
+    case response do
+      %{status: 404} ->
+        []
 
-      song_count =
-        sets
-        |> Enum.flat_map(&Map.get(&1, "song", []))
-        |> length()
+      %{status: 200, body: %{"setlist" => setlists}} ->
+        Enum.map(setlists, fn setlist ->
+          %{
+            "artist" => %{"name" => artist_name},
+            "eventDate" => date,
+            "id" => id,
+            "venue" => %{
+              "name" => venue_name,
+              "city" => city_data
+            },
+            "sets" => %{"set" => sets}
+          } = setlist
 
-      location = build_location(city_data)
+          song_count =
+            sets
+            |> Enum.flat_map(&Map.get(&1, "song", []))
+            |> length()
 
-      %{
-        artist: artist_name,
-        date: format_date(date),
-        id: id,
-        venue: %{name: venue_name, location: location},
-        song_count: song_count
-      }
-    end)
+          location = build_location(city_data)
+
+          %{
+            artist: artist_name,
+            date: format_date(date),
+            id: id,
+            venue: %{name: venue_name, location: location},
+            song_count: song_count
+          }
+        end)
+    end
   end
 
   def get_setlist(id, endpoint \\ @root_endpoint) do

--- a/lib/setlistify_web/live/search_live.ex
+++ b/lib/setlistify_web/live/search_live.ex
@@ -6,7 +6,7 @@ defmodule SetlistifyWeb.SearchLive do
   require OpenTelemetry.Tracer
 
   def mount(_params, _session, socket) do
-    {:ok, assign(socket, setlists: [], search: search_form(%{}))}
+    {:ok, assign(socket, setlists: nil, search: search_form(%{}))}
   end
 
   def handle_params(params, _uri, socket) when params == %{} do
@@ -52,7 +52,7 @@ defmodule SetlistifyWeb.SearchLive do
   def render(assigns) do
     ~H"""
     <div class="scroll-smooth">
-      <%= if @setlists == [] do %>
+      <%= if @setlists == nil do %>
         <.hero_section>
           <div class="flex flex-col h-full items-center justify-between px-4">
             <div class="flex-1 flex flex-col justify-center items-center text-center max-w-3xl mx-auto">
@@ -185,24 +185,30 @@ defmodule SetlistifyWeb.SearchLive do
 
           <h2 class="text-3xl font-bold text-center mb-12">Search Results</h2>
 
-          <ol class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-            <%= for setlist <- @setlists do %>
-              <.link navigate={~p"/setlist/#{setlist.id}"} {tid(["setlist", setlist.id])}>
-                <li class="bg-black/50 border border-gray-800 rounded-xl p-6 hover:border-emerald-500 transition-colors">
-                  <time datetime={setlist.date} class="inline-block mb-3">
-                    <span class="text-sm text-gray-400">
-                      {Calendar.strftime(setlist.date, "%B %d, %Y")}
-                    </span>
-                  </time>
+          <%= if @setlists == [] do %>
+            <p class="text-center text-gray-400 text-lg">No results found</p>
+          <% else %>
+            <ol class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+              <%= for setlist <- @setlists do %>
+                <.link navigate={~p"/setlist/#{setlist.id}"} {tid(["setlist", setlist.id])}>
+                  <li class="bg-black/50 border border-gray-800 rounded-xl p-6 hover:border-emerald-500 transition-colors">
+                    <time datetime={setlist.date} class="inline-block mb-3">
+                      <span class="text-sm text-gray-400">
+                        {Calendar.strftime(setlist.date, "%B %d, %Y")}
+                      </span>
+                    </time>
 
-                  <h3 class="text-lg font-semibold mb-1">{setlist.artist}</h3>
-                  <p class="text-gray-400">{setlist.venue.name}</p>
-                  <p class="text-gray-400 text-sm">{format_location(setlist.venue.location)}</p>
-                  <p class="text-emerald-400 text-sm mt-2">{format_song_count(setlist.song_count)}</p>
-                </li>
-              </.link>
-            <% end %>
-          </ol>
+                    <h3 class="text-lg font-semibold mb-1">{setlist.artist}</h3>
+                    <p class="text-gray-400">{setlist.venue.name}</p>
+                    <p class="text-gray-400 text-sm">{format_location(setlist.venue.location)}</p>
+                    <p class="text-emerald-400 text-sm mt-2">
+                      {format_song_count(setlist.song_count)}
+                    </p>
+                  </li>
+                </.link>
+              <% end %>
+            </ol>
+          <% end %>
         </.section_container>
       <% end %>
     </div>

--- a/test/setlistify/setlist_fm/api/external_client_test.exs
+++ b/test/setlistify/setlist_fm/api/external_client_test.exs
@@ -274,14 +274,14 @@ defmodule Setlistify.SetlistFm.API.ExternalClientTest do
   test "search/1 returns empty list when no results found (404)" do
     Req.Test.stub(MySetlistFmStub, fn
       %{request_path: "/rest/1.0/search/setlists", method: "GET"} = conn ->
-        assert conn.params["artistName"] == "wefwef"
+        assert conn.params["artistName"] == "nonexistent"
 
         conn
         |> Plug.Conn.put_resp_header("content-type", "application/json")
         |> Plug.Conn.send_resp(404, @not_found_response)
     end)
 
-    result = ExternalClient.search("wefwef")
+    result = ExternalClient.search("nonexistent")
     assert result == []
   end
 

--- a/test/setlistify/setlist_fm/api/external_client_test.exs
+++ b/test/setlistify/setlist_fm/api/external_client_test.exs
@@ -268,6 +268,23 @@ defmodule Setlistify.SetlistFm.API.ExternalClientTest do
     assert set_with_encore.venue.location.city == "Nashville"
   end
 
+  @not_found_response fixture_dir()
+                      |> Path.join("setlist_fm_search_404_response.json")
+                      |> File.read!()
+  test "search/1 returns empty list when no results found (404)" do
+    Req.Test.stub(MySetlistFmStub, fn
+      %{request_path: "/rest/1.0/search/setlists", method: "GET"} = conn ->
+        assert conn.params["artistName"] == "wefwef"
+
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.send_resp(404, @not_found_response)
+    end)
+
+    result = ExternalClient.search("wefwef")
+    assert result == []
+  end
+
   test "search/1 handles sets with missing or empty song arrays" do
     response = %{
       "setlist" => [

--- a/test/setlistify_web/live/search_live_test.exs
+++ b/test/setlistify_web/live/search_live_test.exs
@@ -48,6 +48,18 @@ defmodule SetlistifyWeb.SearchLiveTest do
     assert_redirected(view, ~p"/setlist/#{setlist_id}")
   end
 
+  test "displays 'No results found' when search returns empty list", %{conn: conn} do
+    expect(SetlistFm.API.MockClient, :search, 1, fn "nonexistent" ->
+      []
+    end)
+
+    {:ok, view, _html} = live(conn, ~p"/")
+
+    html = view |> form("[name='search']", %{search: %{query: "nonexistent"}}) |> render_submit()
+
+    assert html =~ "No results found"
+  end
+
   test "displays song count in search results", %{conn: conn} do
     expect(SetlistFm.API.MockClient, :search, 1, fn "test artist" ->
       [

--- a/test/support/fixtures/setlist_fm_search_404_response.json
+++ b/test/support/fixtures/setlist_fm_search_404_response.json
@@ -1,0 +1,6 @@
+{
+  "code": 404,
+  "message": "not found",
+  "status": "Not Found",
+  "timestamp": "2025-06-01T23:35:52.272+0000"
+}


### PR DESCRIPTION
## Summary
- Fix MatchError crash when Setlist.fm returns 404 for searches with no results
- Add "No results found" message when search returns empty results
- Disable PromEx in test environment to prevent port conflicts

## Test plan
- [x] Added test for ExternalClient handling 404 responses
- [x] Added test for SearchLive displaying "No results found"
- [x] All tests passing (except one unrelated test)

🤖 Generated with [Claude Code](https://claude.ai/code)