### PR TITLE
Disable PromEx metrics server in test environment

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -263,21 +263,23 @@ else
       name: System.get_env("HOSTNAME", "localhost")
     ]
 
-  # Local PromEx configuration
-  config :setlistify, Setlistify.PromEx,
-    manual_metrics_start_delay: :no_delay,
-    drop_metrics_groups: [],
-    grafana: [
-      host: "http://localhost:3000",
-      auth_token: "admin:admin",
-      upload_dashboards_on_start: true,
-      folder_name: "Setlistify Dashboards",
-      annotate_app_lifecycle: true
-    ],
-    metrics_server: [
-      port: String.to_integer(System.get_env("PROM_EX_PORT", "9568")),
-      path: "/metrics"
-    ]
+  # Local PromEx configuration (skip for test environment)
+  if config_env() != :test do
+    config :setlistify, Setlistify.PromEx,
+      manual_metrics_start_delay: :no_delay,
+      drop_metrics_groups: [],
+      grafana: [
+        host: "http://localhost:3000",
+        auth_token: "admin:admin",
+        upload_dashboards_on_start: true,
+        folder_name: "Setlistify Dashboards",
+        annotate_app_lifecycle: true
+      ],
+      metrics_server: [
+        port: String.to_integer(System.get_env("PROM_EX_PORT", "9568")),
+        path: "/metrics"
+      ]
+  end
 
   # Local Loki configuration
   config :logger, Setlistify.LokiLogger,

--- a/config/test.exs
+++ b/config/test.exs
@@ -28,10 +28,7 @@ config :setlistify,
 config :opentelemetry,
   traces_exporter: :none
 
-# Configure PromEx for tests with a different port to avoid conflicts
+# Disable PromEx for tests
 config :setlistify, Setlistify.PromEx,
   grafana: :disabled,
-  metrics_server: [
-    port: 9590,
-    path: "/metrics"
-  ]
+  metrics_server: :disabled


### PR DESCRIPTION
## Summary
- Skip PromEx configuration in runtime.exs when running tests to prevent port conflicts
- Update test.exs to fully disable PromEx metrics server

## Why?
Tests were failing to start because PromEx was trying to bind to port 9590 which could end up being used if we have multiple instances of our application running. This change avoids the issue by not configuring PromEx to not start its metrics server during test runs.

## Test plan
- [x] Run `mix test` - all tests should pass without port conflicts

🤖 Generated with [Claude Code](https://claude.ai/code)