### PR TITLE
fix: prevent mobile zoom on search input focus

### DIFF
--- a/lib/setlistify_web/live/components/search_form_component.ex
+++ b/lib/setlistify_web/live/components/search_form_component.ex
@@ -34,7 +34,7 @@ defmodule SetlistifyWeb.Components.SearchFormComponent do
               placeholder="Search for an artist or band..."
               autocomplete="off"
               class={[
-                "w-full px-4 sm:px-6 py-4 sm:py-5 pr-14 sm:pr-16 text-sm sm:text-base text-white bg-gradient-to-r from-gray-900 to-gray-800 border rounded-full placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-emerald-400 focus:ring-opacity-50 focus:border-emerald-500 shadow-lg focus:shadow-emerald-500/25",
+                "w-full px-4 sm:px-6 py-4 sm:py-5 pr-14 sm:pr-16 text-base text-white bg-gradient-to-r from-gray-900 to-gray-800 border rounded-full placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-emerald-400 focus:ring-opacity-50 focus:border-emerald-500 shadow-lg focus:shadow-emerald-500/25",
                 if(Enum.empty?(@search[:query].errors || []),
                   do: "border-gray-700 hover:border-gray-600",
                   else: "border-rose-400"


### PR DESCRIPTION
## Summary
This PR fixes the mobile zoom issue that occurs when users tap on the search input field.

## Problem
On mobile devices, when the search input had a font size less than 16px (using `text-sm` which is 14px), browsers would automatically zoom in when the input was focused. This created a poor user experience.

## Solution
Changed the search input font size from `text-sm sm:text-base` to just `text-base` (16px) across all device sizes. This prevents the automatic zoom behavior on mobile browsers while maintaining a consistent appearance.

## Test plan
- [x] Open the app on a mobile device or mobile browser emulator
- [x] Tap on the search input field
- [x] Verify that the browser does not zoom in
- [x] Verify the input still looks good on desktop

🤖 Generated with [Claude Code](https://claude.ai/code)