### PR TITLE
fix: correct JSON syntax in .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,8 +19,8 @@
       "WebFetch(domain:github.com)",
       "WebFetch(domain:hex.pm)",
       "mcp__Context7__get-library-docs",
-      "mcp__Context7__resolve-library-id"
-      "mcp__puppeteer*",
+      "mcp__Context7__resolve-library-id",
+      "mcp__puppeteer*"
     ],
     "deny": []
   }


### PR DESCRIPTION
## Summary

- Fixed missing comma after `mcp__Context7__resolve-library-id` entry
- Removed trailing comma after `mcp__puppeteer*` entry

Both issues caused invalid JSON in the Claude Code permissions config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)