### PR TITLE
chore: remove preview_url and rename uri to track_id in Spotify API

### DIFF
--- a/lib/setlistify/spotify/api.ex
+++ b/lib/setlistify/spotify/api.ex
@@ -5,7 +5,7 @@ defmodule Setlistify.Spotify.API do
 
   # TODO Set response type
   @callback search_for_track(UserSession.t(), String.t(), String.t()) ::
-              nil | %{uri: String.t(), preview_url: String.t()}
+              nil | %{track_id: String.t()}
   def search_for_track(user_session, artist, track) do
     OpenTelemetry.Tracer.with_span "Setlistify.Spotify.API.search_for_track" do
       OpenTelemetry.Tracer.set_attributes([

--- a/lib/setlistify/spotify/api/external_client.ex
+++ b/lib/setlistify/spotify/api/external_client.ex
@@ -97,7 +97,7 @@ defmodule Setlistify.Spotify.API.ExternalClient do
                   {"spotify.track.uri", track_info["uri"]}
                 ])
 
-                %{uri: track_info["uri"], preview_url: track_info["preview_url"]}
+                %{track_id: track_info["uri"]}
             end
 
           OpenTelemetry.Tracer.set_status(:ok, "")

--- a/lib/setlistify_web/live/setlists/show_live.ex
+++ b/lib/setlistify_web/live/setlists/show_live.ex
@@ -117,7 +117,7 @@ defmodule SetlistifyWeb.Setlists.ShowLive do
               |> Enum.map(fn {_song, song_index} ->
                 async_key = String.to_atom("song_#{set_index}_#{song_index}")
                 result = Map.get(socket.assigns, async_key).result
-                result[:spotify_info].uri
+                result[:spotify_info].track_id
               end)
             end)
 

--- a/test/setlistify/spotify/api/external_client_test.exs
+++ b/test/setlistify/spotify/api/external_client_test.exs
@@ -44,7 +44,7 @@ defmodule Setlistify.Spotify.Api.ExternalClientTest do
 
       result = ExternalClient.search_for_track(user_session, "some artist", "some track")
 
-      assert result.uri =~ ~r"spotify:track:\w+"
+      assert result.track_id =~ ~r"spotify:track:\w+"
     end
 
     test "returns nil if no tracks are found", %{user_session: user_session} do
@@ -879,7 +879,7 @@ defmodule Setlistify.Spotify.Api.ExternalClientTest do
       # 3. Retry with the new token
       # 4. Successfully complete the search
       assert result
-      assert result.uri =~ ~r"spotify:track:\w+"
+      assert result.track_id =~ ~r"spotify:track:\w+"
     end
   end
 end

--- a/test/setlistify_web/live/setlists/show_live_test.exs
+++ b/test/setlistify_web/live/setlists/show_live_test.exs
@@ -132,7 +132,7 @@ defmodule SetlistifyWeb.Setlists.ShowLiveTest do
       case title do
         "song1" ->
           # We have a match for song
-          %{uri: "spotify:track:123", preview_url: "http://www.example.com"}
+          %{track_id: "spotify:track:123"}
 
         "song2" ->
           # We cannot find a match for the song
@@ -197,7 +197,7 @@ defmodule SetlistifyWeb.Setlists.ShowLiveTest do
       case title do
         "song1" ->
           # We have a match for song
-          %{uri: "spotify:track:123", preview_url: "http://www.example.com"}
+          %{track_id: "spotify:track:123"}
 
         "song2" ->
           # We cannot find a match for the song


### PR DESCRIPTION
## Summary

- Removed `preview_url` from Spotify search result — fetched from the API but never read
- Renamed `uri` → `track_id` for provider-opaque naming per ADR-003
- Updated `@callback search_for_track` return type in `Spotify.API`
- Updated test mock return values and assertions in `external_client_test.exs` and `show_live_test.exs`
- Updated `show_live.ex` to access `result[:spotify_info].track_id` instead of `.uri`

## Part of
Phase 1: Preparatory Refactors to Spotify (Apple Music Integration)

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)