### PR TITLE
chore: add :auth_provider to session and namespace Registry keys

### DIFF
--- a/lib/setlistify/spotify/session_manager.ex
+++ b/lib/setlistify/spotify/session_manager.ex
@@ -370,7 +370,7 @@ defmodule Setlistify.Spotify.SessionManager do
   # Helper functions
 
   defp via_tuple(user_id) do
-    {:via, Registry, {Setlistify.UserSessionRegistry, user_id}}
+    {:via, Registry, {Setlistify.UserSessionRegistry, {:spotify, user_id}}}
   end
 
   @doc """
@@ -378,7 +378,7 @@ defmodule Setlistify.Spotify.SessionManager do
   Returns {:ok, pid} if found, :error otherwise.
   """
   def lookup(user_id) do
-    case Registry.lookup(Setlistify.UserSessionRegistry, user_id) do
+    case Registry.lookup(Setlistify.UserSessionRegistry, {:spotify, user_id}) do
       [{pid, _}] -> {:ok, pid}
       [] -> :error
     end

--- a/lib/setlistify_web/controllers/oauth_callback_controller.ex
+++ b/lib/setlistify_web/controllers/oauth_callback_controller.ex
@@ -75,6 +75,7 @@ defmodule SetlistifyWeb.OAuthCallbackController do
           SessionSupervisor.start_user_token(user_session.user_id, user_session)
 
           conn
+          |> put_session(:auth_provider, "spotify")
           |> put_session(:refresh_token, encrypted_refresh_token)
           |> put_session(:user_id, user_session.user_id)
           |> UserAuth.auth_user(user_session.user_id)

--- a/lib/setlistify_web/plugs/restore_spotify_token.ex
+++ b/lib/setlistify_web/plugs/restore_spotify_token.ex
@@ -13,6 +13,16 @@ defmodule SetlistifyWeb.Plugs.RestoreSpotifyToken do
   def init(opts), do: opts
 
   def call(conn, _opts) do
+    auth_provider = get_session(conn, :auth_provider)
+
+    if auth_provider != "spotify" do
+      conn
+    else
+      do_call(conn)
+    end
+  end
+
+  defp do_call(conn) do
     user_id = get_session(conn, :user_id)
     refresh_token = get_session(conn, :refresh_token)
 

--- a/lib/setlistify_web/plugs/restore_spotify_token.ex
+++ b/lib/setlistify_web/plugs/restore_spotify_token.ex
@@ -26,7 +26,8 @@ defmodule SetlistifyWeb.Plugs.RestoreSpotifyToken do
     user_id = get_session(conn, :user_id)
     refresh_token = get_session(conn, :refresh_token)
 
-    with user_id when not is_nil(user_id) <- user_id,
+    with "spotify" <- get_session(conn, :auth_provider),
+         user_id when not is_nil(user_id) <- user_id,
          {:error, :not_found} <- SessionManager.get_session(user_id),
          encrypted_token when not is_nil(encrypted_token) <- refresh_token,
          {:ok, refresh_token} <-
@@ -48,8 +49,7 @@ defmodule SetlistifyWeb.Plugs.RestoreSpotifyToken do
           )
       end
     else
-      _ ->
-        conn
+      _ -> conn
     end
   end
 end

--- a/test/setlistify_web/controllers/oauth_callback_controller_test.exs
+++ b/test/setlistify_web/controllers/oauth_callback_controller_test.exs
@@ -11,7 +11,7 @@ defmodule SetlistifyWeb.OAuthCallbackControllerTest do
     test_user = "user_#{System.unique_integer([:positive])}"
 
     # Clean up session manager for the test user to avoid interference between tests
-    case Registry.lookup(Setlistify.UserSessionRegistry, test_user) do
+    case Registry.lookup(Setlistify.UserSessionRegistry, {:spotify, test_user}) do
       [{pid, _}] -> GenServer.stop(pid)
       [] -> :ok
     end
@@ -109,7 +109,7 @@ defmodule SetlistifyWeb.OAuthCallbackControllerTest do
       assert get_session(conn, :refresh_token) == "some_token"
 
       # Start a session process using the supervisor to properly register it
-      assert Registry.lookup(Setlistify.UserSessionRegistry, test_user) == []
+      assert Registry.lookup(Setlistify.UserSessionRegistry, {:spotify, test_user}) == []
 
       user_session = %Setlistify.Spotify.UserSession{
         access_token: "test",
@@ -123,7 +123,8 @@ defmodule SetlistifyWeb.OAuthCallbackControllerTest do
       assert Process.alive?(original_pid)
 
       # Verify process is registered with the Registry
-      assert [{^original_pid, _}] = Registry.lookup(Setlistify.UserSessionRegistry, test_user)
+      assert [{^original_pid, _}] =
+               Registry.lookup(Setlistify.UserSessionRegistry, {:spotify, test_user})
 
       # Do the sign-out
       sign_out_conn = get(conn, "/signout")

--- a/test/setlistify_web/plugs/restore_spotify_token_test.exs
+++ b/test/setlistify_web/plugs/restore_spotify_token_test.exs
@@ -48,6 +48,7 @@ defmodule SetlistifyWeb.Plugs.RestoreSpotifyTokenTest do
         conn
         |> init_test_session(%{})
         |> fetch_flash()
+        |> put_session(:auth_provider, "spotify")
         |> put_session(:user_id, user_id)
         |> RestoreSpotifyToken.call([])
 
@@ -56,7 +57,7 @@ defmodule SetlistifyWeb.Plugs.RestoreSpotifyTokenTest do
 
     test "restores session process from valid refresh token", %{conn: conn, user_id: user_id} do
       # Ensure there is no existing session process
-      case Registry.lookup(Setlistify.UserSessionRegistry, user_id) do
+      case Registry.lookup(Setlistify.UserSessionRegistry, {:spotify, user_id}) do
         [{pid, _}] -> GenServer.stop(pid)
         [] -> :ok
       end
@@ -87,6 +88,7 @@ defmodule SetlistifyWeb.Plugs.RestoreSpotifyTokenTest do
         conn
         |> init_test_session(%{})
         |> fetch_flash()
+        |> put_session(:auth_provider, "spotify")
         |> put_session(:user_id, user_id)
         |> put_session(:refresh_token, encrypted_token)
         |> RestoreSpotifyToken.call([])
@@ -123,6 +125,7 @@ defmodule SetlistifyWeb.Plugs.RestoreSpotifyTokenTest do
         conn
         |> init_test_session(%{})
         |> fetch_flash()
+        |> put_session(:auth_provider, "spotify")
         |> put_session(:user_id, user_id)
         |> put_session(:refresh_token, encrypted_token)
         |> RestoreSpotifyToken.call([])

--- a/test/support/registry_helpers.ex
+++ b/test/support/registry_helpers.ex
@@ -42,7 +42,7 @@ defmodule Setlistify.Test.RegistryHelpers do
     import ExUnit.Assertions, only: [flunk: 1]
 
     Enum.reduce_while(1..max_attempts, nil, fn attempt, _ ->
-      case Registry.lookup(Setlistify.UserSessionRegistry, user_id) do
+      case Registry.lookup(Setlistify.UserSessionRegistry, {:spotify, user_id}) do
         [{pid, _}] ->
           {:halt, pid}
 
@@ -102,7 +102,7 @@ defmodule Setlistify.Test.RegistryHelpers do
     import ExUnit.Assertions, only: [flunk: 1]
 
     Enum.reduce_while(1..max_attempts, nil, fn attempt, _ ->
-      case Registry.lookup(Setlistify.UserSessionRegistry, user_id) do
+      case Registry.lookup(Setlistify.UserSessionRegistry, {:spotify, user_id}) do
         [] ->
           {:halt, true}
 


### PR DESCRIPTION
## Summary

- Stores `:auth_provider` in the session cookie (value `"spotify"`) on Spotify OAuth callback so future providers can be distinguished
- Namespaces `Setlistify.UserSessionRegistry` keys as `{:spotify, user_id}` tuples to prevent ID collisions between Spotify and Apple Music users
- Guards `RestoreSpotifyToken` plug to skip processing when `auth_provider` is not `"spotify"`, making it safe to run even when an Apple Music user is logged in

## Why

This is Phase 1 preparation for Apple Music integration (ADR-003). Without namespaced Registry keys, a Spotify user and an Apple Music user with the same account ID would collide in the process Registry. Adding `:auth_provider` to the session enables routing to the correct provider-specific logic throughout the web layer.

## Test plan

- [x] All existing tests pass (`mix test` - 155 tests, 0 failures)
- [x] Updated `RegistryHelpers` (`assert_in_registry`/`refute_in_registry`) to use `{:spotify, user_id}` keys
- [x] Updated direct `Registry.lookup` calls in `oauth_callback_controller_test.exs` and `restore_spotify_token_test.exs`
- [x] Added `put_session(:auth_provider, "spotify")` to test sessions that expect Spotify token restoration

Closes #64
Part of Phase 1 Apple Music Integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)