### PR TITLE
chore: replace service.name with peer.service in OTel span attributes

### DIFF
--- a/lib/setlistify/setlist_fm/api.ex
+++ b/lib/setlistify/setlist_fm/api.ex
@@ -55,7 +55,7 @@ defmodule Setlistify.SetlistFm.API do
   def search(query, page \\ 1) do
     OpenTelemetry.Tracer.with_span "Setlistify.SetlistFm.API.search" do
       OpenTelemetry.Tracer.set_attributes([
-        {"service.name", "setlist_fm"},
+        {"peer.service", "setlist_fm"},
         {"setlist_fm.operation", "search"},
         {"setlist_fm.search.query", query},
         {"setlist_fm.search.page", page}
@@ -94,7 +94,7 @@ defmodule Setlistify.SetlistFm.API do
   def get_setlist(id) do
     OpenTelemetry.Tracer.with_span "Setlistify.SetlistFm.API.get_setlist" do
       OpenTelemetry.Tracer.set_attributes([
-        {"service.name", "setlist_fm"},
+        {"peer.service", "setlist_fm"},
         {"setlist_fm.operation", "get_setlist"},
         {"setlist_fm.setlist.id", id}
       ])

--- a/lib/setlistify/setlist_fm/api/external_client.ex
+++ b/lib/setlistify/setlist_fm/api/external_client.ex
@@ -9,7 +9,7 @@ defmodule Setlistify.SetlistFm.API.ExternalClient do
   def search(query, page, endpoint \\ @root_endpoint) do
     OpenTelemetry.Tracer.with_span "Setlistify.SetlistFm.API.ExternalClient.search" do
       OpenTelemetry.Tracer.set_attributes([
-        {"service.name", "setlist_fm"},
+        {"peer.service", "setlist_fm"},
         {"setlist_fm.operation", "search"},
         {"setlist_fm.search.query", query},
         {"setlist_fm.search.page", page},
@@ -120,7 +120,7 @@ defmodule Setlistify.SetlistFm.API.ExternalClient do
   def get_setlist(id, endpoint \\ @root_endpoint) do
     OpenTelemetry.Tracer.with_span "Setlistify.SetlistFm.API.ExternalClient.get_setlist" do
       OpenTelemetry.Tracer.set_attributes([
-        {"service.name", "setlist_fm"},
+        {"peer.service", "setlist_fm"},
         {"setlist_fm.operation", "get_setlist"},
         {"setlist_fm.setlist.id", id},
         {"http.url", "#{endpoint}/setlist/#{id}"}

--- a/lib/setlistify/spotify/api.ex
+++ b/lib/setlistify/spotify/api.ex
@@ -9,7 +9,7 @@ defmodule Setlistify.Spotify.API do
   def search_for_track(user_session, artist, track) do
     OpenTelemetry.Tracer.with_span "Setlistify.Spotify.API.search_for_track" do
       OpenTelemetry.Tracer.set_attributes([
-        {"service.name", "spotify"},
+        {"peer.service", "spotify"},
         {"spotify.operation", "search_track"},
         {"spotify.artist", artist},
         {"spotify.track", track},
@@ -38,7 +38,7 @@ defmodule Setlistify.Spotify.API do
   def create_playlist(user_session, name, description) do
     OpenTelemetry.Tracer.with_span "Setlistify.Spotify.API.create_playlist" do
       OpenTelemetry.Tracer.set_attributes([
-        {"service.name", "spotify"},
+        {"peer.service", "spotify"},
         {"spotify.operation", "create_playlist"},
         {"spotify.playlist.name", name},
         {"user.id", user_session.user_id},
@@ -54,7 +54,7 @@ defmodule Setlistify.Spotify.API do
   def add_tracks_to_playlist(user_session, playlist_id, tracks) do
     OpenTelemetry.Tracer.with_span "Setlistify.Spotify.API.add_tracks_to_playlist" do
       OpenTelemetry.Tracer.set_attributes([
-        {"service.name", "spotify"},
+        {"peer.service", "spotify"},
         {"spotify.operation", "add_tracks_to_playlist"},
         {"spotify.playlist.id", playlist_id},
         {"spotify.tracks.count", length(tracks)},
@@ -70,7 +70,7 @@ defmodule Setlistify.Spotify.API do
   def get_embed(url) do
     OpenTelemetry.Tracer.with_span "Setlistify.Spotify.API.get_embed" do
       OpenTelemetry.Tracer.set_attributes([
-        {"service.name", "spotify"},
+        {"peer.service", "spotify"},
         {"spotify.operation", "get_embed"},
         {"spotify.embed.url", url}
       ])
@@ -85,7 +85,7 @@ defmodule Setlistify.Spotify.API do
   def refresh_token(refresh_token) do
     OpenTelemetry.Tracer.with_span "Setlistify.Spotify.API.refresh_token" do
       OpenTelemetry.Tracer.set_attributes([
-        {"service.name", "spotify"},
+        {"peer.service", "spotify"},
         {"spotify.operation", "refresh_token"},
         {"oauth.grant_type", "refresh_token"}
       ])
@@ -100,7 +100,7 @@ defmodule Setlistify.Spotify.API do
   def exchange_code(code, redirect_uri) do
     OpenTelemetry.Tracer.with_span "Setlistify.Spotify.API.exchange_code" do
       OpenTelemetry.Tracer.set_attributes([
-        {"service.name", "spotify"},
+        {"peer.service", "spotify"},
         {"spotify.operation", "exchange_code"},
         {"oauth.grant_type", "authorization_code"},
         {"oauth.redirect_uri", redirect_uri}
@@ -116,7 +116,7 @@ defmodule Setlistify.Spotify.API do
   def refresh_to_user_session(refresh_token) do
     OpenTelemetry.Tracer.with_span "Setlistify.Spotify.API.refresh_to_user_session" do
       OpenTelemetry.Tracer.set_attributes([
-        {"service.name", "spotify"},
+        {"peer.service", "spotify"},
         {"spotify.operation", "refresh_to_user_session"},
         {"oauth.grant_type", "refresh_token"}
       ])

--- a/lib/setlistify/spotify/api/external_client.ex
+++ b/lib/setlistify/spotify/api/external_client.ex
@@ -138,7 +138,7 @@ defmodule Setlistify.Spotify.API.ExternalClient do
   def create_playlist(user_session, name, description) do
     OpenTelemetry.Tracer.with_span "Setlistify.Spotify.API.ExternalClient.create_playlist" do
       OpenTelemetry.Tracer.set_attributes([
-        {"service.name", "spotify"},
+        {"peer.service", "spotify"},
         {"spotify.operation", "create_playlist"},
         {"spotify.playlist.name", name},
         {"user.id", user_session.user_id},
@@ -207,7 +207,7 @@ defmodule Setlistify.Spotify.API.ExternalClient do
   def add_tracks_to_playlist(user_session, playlist_id, tracks) do
     OpenTelemetry.Tracer.with_span "Setlistify.Spotify.API.ExternalClient.add_tracks_to_playlist" do
       OpenTelemetry.Tracer.set_attributes([
-        {"service.name", "spotify"},
+        {"peer.service", "spotify"},
         {"spotify.operation", "add_tracks_to_playlist"},
         {"spotify.playlist.id", playlist_id},
         {"spotify.tracks.count", length(tracks)},
@@ -429,7 +429,7 @@ defmodule Setlistify.Spotify.API.ExternalClient do
   defp build_user_session_from_tokens(tokens) do
     OpenTelemetry.Tracer.with_span "Setlistify.Spotify.API.ExternalClient.build_user_session_from_tokens" do
       OpenTelemetry.Tracer.set_attributes([
-        {"service.name", "spotify"},
+        {"peer.service", "spotify"},
         {"spotify.operation", "fetch_user_profile"}
       ])
 


### PR DESCRIPTION
## Summary

- Corrects misuse of the `service.name` OpenTelemetry semantic convention across Spotify and Setlist.fm instrumentation. `service.name` is a **resource attribute** that identifies this application itself and must not be set per-span to name a remote dependency.
- Replaces all `{"service.name", "spotify"}` and `{"service.name", "setlist_fm"}` span attributes with `{"peer.service", "<name>"}`, which is the correct OTel semantic convention for identifying the remote service being called.
- Leaves `{"music.service", "spotify"}` on the LiveView async song-search span unchanged — this is an intentional trace-level filter for which music provider is active, not a peer service identification attribute.

## What changed in each file

- **`lib/setlistify/spotify/api.ex`** — Replaced `{"service.name", "spotify"}` with `{"peer.service", "spotify"}` on all 7 spans (`search_for_track`, `create_playlist`, `add_tracks_to_playlist`, `get_embed`, `refresh_token`, `exchange_code`, `refresh_to_user_session`).
- **`lib/setlistify/spotify/api/external_client.ex`** — Same replacement on `create_playlist`, `add_tracks_to_playlist`, and `build_user_session_from_tokens` spans.
- **`lib/setlistify/setlist_fm/api.ex`** — Replaced `{"service.name", "setlist_fm"}` with `{"peer.service", "setlist_fm"}` on `search` and `get_setlist` spans.
- **`lib/setlistify/setlist_fm/api/external_client.ex`** — Same replacement on `search` and `get_setlist` spans.

## Test plan

- [x] `mix compile` — no errors
- [x] `mix test` — 155 tests, 0 failures
- [x] `mix format` — no changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)