### PR TITLE
feat: add AppleMusic.UserSession, SessionManager, and UserSessionManager dispatch (#67)

### DIFF
--- a/lib/setlistify/apple_music/session_manager.ex
+++ b/lib/setlistify/apple_music/session_manager.ex
@@ -6,7 +6,7 @@ defmodule Setlistify.AppleMusic.SessionManager do
   Apple Music user tokens are valid for approximately six months with no
   server-side refresh endpoint. This GenServer stores the session as-is —
   there is no refresh timer, no scheduled token rotation, and no PubSub
-  broadcast on token change. The simplicity is intentional.
+  broadcast on token change.
   """
 
   use GenServer

--- a/lib/setlistify/apple_music/session_manager.ex
+++ b/lib/setlistify/apple_music/session_manager.ex
@@ -1,0 +1,115 @@
+defmodule Setlistify.AppleMusic.SessionManager do
+  @moduledoc """
+  GenServer that stores an Apple Music user session for the duration of a
+  user's browser session.
+
+  Apple Music user tokens are valid for approximately six months with no
+  server-side refresh endpoint. This GenServer stores the session as-is —
+  there is no refresh timer, no scheduled token rotation, and no PubSub
+  broadcast on token change. The simplicity is intentional.
+  """
+
+  use GenServer
+  require Logger
+  require OpenTelemetry.Tracer
+
+  @behaviour Setlistify.UserSessionManager
+
+  alias Setlistify.AppleMusic.UserSession
+
+  @impl Setlistify.UserSessionManager
+  def start_link({user_id, %UserSession{} = session}) do
+    OpenTelemetry.Tracer.with_span "Setlistify.AppleMusic.SessionManager.start_link" do
+      OpenTelemetry.Tracer.set_attributes([
+        {"user.id", user_id},
+        {"enduser.id", user_id},
+        {"session.operation", "start"}
+      ])
+
+      case GenServer.start_link(__MODULE__, session, name: via_tuple(user_id)) do
+        {:ok, pid} = result ->
+          Logger.info("Apple Music session manager started", %{
+            user_id: user_id,
+            pid: inspect(pid)
+          })
+
+          OpenTelemetry.Tracer.set_status(:ok, "")
+          result
+
+        {:error, reason} = error ->
+          Logger.error("Failed to start Apple Music session manager", %{
+            user_id: user_id,
+            error: reason
+          })
+
+          OpenTelemetry.Tracer.set_status(
+            :error,
+            "Failed to start session manager: #{inspect(reason)}"
+          )
+
+          error
+      end
+    end
+  end
+
+  @impl Setlistify.UserSessionManager
+  def get_session(user_id) do
+    OpenTelemetry.Tracer.with_span "Setlistify.AppleMusic.SessionManager.get_session" do
+      OpenTelemetry.Tracer.set_attributes([
+        {"user.id", user_id},
+        {"enduser.id", user_id},
+        {"session.operation", "get"}
+      ])
+
+      case lookup(user_id) do
+        {:ok, pid} ->
+          result = {:ok, GenServer.call(pid, :get_session)}
+          OpenTelemetry.Tracer.set_status(:ok, "")
+          result
+
+        :error ->
+          OpenTelemetry.Tracer.set_status(:error, "Session not found")
+          {:error, :not_found}
+      end
+    end
+  end
+
+  @impl Setlistify.UserSessionManager
+  def stop(user_id) do
+    OpenTelemetry.Tracer.with_span "Setlistify.AppleMusic.SessionManager.stop" do
+      OpenTelemetry.Tracer.set_attributes([
+        {"user.id", user_id},
+        {"enduser.id", user_id},
+        {"session.operation", "stop"}
+      ])
+
+      case lookup(user_id) do
+        {:ok, pid} ->
+          GenServer.stop(pid, :normal)
+          Logger.info("Apple Music session manager stopped", %{user_id: user_id})
+          OpenTelemetry.Tracer.set_status(:ok, "")
+          :ok
+
+        :error ->
+          OpenTelemetry.Tracer.set_status(:error, "Session not found")
+          {:error, :not_found}
+      end
+    end
+  end
+
+  def lookup(user_id) do
+    case Registry.lookup(Setlistify.UserSessionRegistry, {:apple_music, user_id}) do
+      [{pid, _}] -> {:ok, pid}
+      [] -> :error
+    end
+  end
+
+  @impl true
+  def init(%UserSession{} = session), do: {:ok, session}
+
+  @impl true
+  def handle_call(:get_session, _from, session), do: {:reply, session, session}
+
+  defp via_tuple(user_id),
+    do: {:via, Registry, {Setlistify.UserSessionRegistry, {:apple_music, user_id}}}
+end

--- a/lib/setlistify/apple_music/user_session.ex
+++ b/lib/setlistify/apple_music/user_session.ex
@@ -1,0 +1,10 @@
+defmodule Setlistify.AppleMusic.UserSession do
+  @type t :: %__MODULE__{
+          user_token: String.t(),
+          user_id: String.t(),
+          storefront: String.t()
+        }
+
+  @enforce_keys [:user_token, :user_id, :storefront]
+  defstruct [:user_token, :user_id, :storefront]
+end

--- a/lib/setlistify/spotify/session_manager.ex
+++ b/lib/setlistify/spotify/session_manager.ex
@@ -89,6 +89,9 @@ defmodule Setlistify.Spotify.SessionManager do
   use GenServer
   require Logger
   require OpenTelemetry.Tracer
+
+  @behaviour Setlistify.UserSessionManager
+
   alias Setlistify.Spotify.API
   alias Setlistify.Spotify.UserSession
 
@@ -98,6 +101,7 @@ defmodule Setlistify.Spotify.SessionManager do
 
   # Client API
 
+  @impl Setlistify.UserSessionManager
   def start_link({user_id, initial_tokens_or_session}) do
     OpenTelemetry.Tracer.with_span "Setlistify.Spotify.SessionManager.start_link" do
       OpenTelemetry.Tracer.set_attributes([
@@ -197,6 +201,7 @@ defmodule Setlistify.Spotify.SessionManager do
     end
   end
 
+  @impl Setlistify.UserSessionManager
   def get_session(user_id) do
     OpenTelemetry.Tracer.with_span "Setlistify.Spotify.SessionManager.get_session" do
       OpenTelemetry.Tracer.set_attributes([
@@ -226,6 +231,7 @@ defmodule Setlistify.Spotify.SessionManager do
     end
   end
 
+  @impl Setlistify.UserSessionManager
   def stop(user_id) do
     OpenTelemetry.Tracer.with_span "Setlistify.Spotify.SessionManager.stop" do
       OpenTelemetry.Tracer.set_attributes([

--- a/lib/setlistify/user_session_manager.ex
+++ b/lib/setlistify/user_session_manager.ex
@@ -5,16 +5,16 @@ defmodule Setlistify.UserSessionManager do
   Two dispatch patterns are used depending on whether the caller has the
   session in hand:
 
-  - **Session struct** — used at session creation time, when the full
+  - Session struct — used at session creation time, when the full
     `UserSession` struct is available. Dispatch is by struct type, so no
     provider argument is needed.
 
-  - **Provider key tuple** — used for lookups and teardown, when the session
+  - Provider key tuple — used for lookups and teardown, when the session
     hasn't been fetched yet and only the provider + user ID are known (e.g.
     from a session cookie). The tuple mirrors the Registry key format used
     internally.
 
-  Provider key format: `{:spotify, user_id}` / `{:apple_music, user_id}`
+    Provider key format: `{:provider, user_id}`
   """
 
   alias Setlistify.{Spotify, AppleMusic}

--- a/lib/setlistify/user_session_manager.ex
+++ b/lib/setlistify/user_session_manager.ex
@@ -1,0 +1,37 @@
+defmodule Setlistify.UserSessionManager do
+  @moduledoc """
+  Provider-agnostic dispatch layer for user session management.
+
+  Two dispatch patterns are used depending on whether the caller has the
+  session in hand:
+
+  - **Session struct** — used at session creation time, when the full
+    `UserSession` struct is available. Dispatch is by struct type, so no
+    provider argument is needed.
+
+  - **Provider key tuple** — used for lookups and teardown, when the session
+    hasn't been fetched yet and only the provider + user ID are known (e.g.
+    from a session cookie). The tuple mirrors the Registry key format used
+    internally.
+
+  Provider key format: `{:spotify, user_id}` / `{:apple_music, user_id}`
+  """
+
+  alias Setlistify.{Spotify, AppleMusic}
+
+  @type provider_key :: {:spotify, String.t()} | {:apple_music, String.t()}
+  @type user_session :: Spotify.UserSession.t() | AppleMusic.UserSession.t()
+
+  @callback start_link({String.t(), user_session()}) :: GenServer.on_start()
+  @callback get_session(String.t()) :: {:ok, user_session()} | {:error, :not_found}
+  @callback stop(String.t()) :: :ok | {:error, :not_found}
+
+  defp impl(%Spotify.UserSession{}), do: Spotify.SessionManager
+  defp impl(%AppleMusic.UserSession{}), do: AppleMusic.SessionManager
+  defp impl({:spotify, _}), do: Spotify.SessionManager
+  defp impl({:apple_music, _}), do: AppleMusic.SessionManager
+
+  def start(%_{user_id: uid} = session), do: impl(session).start_link({uid, session})
+  def get_session({_, uid} = key), do: impl(key).get_session(uid)
+  def stop({_, uid} = key), do: impl(key).stop(uid)
+end

--- a/test/setlistify/apple_music/session_manager_test.exs
+++ b/test/setlistify/apple_music/session_manager_test.exs
@@ -1,0 +1,67 @@
+defmodule Setlistify.AppleMusic.SessionManagerTest do
+  use ExUnit.Case, async: true
+
+  import Setlistify.Test.RegistryHelpers
+
+  alias Setlistify.AppleMusic.{SessionManager, UserSession}
+
+  setup do
+    user_id = unique_user_id()
+
+    session = %UserSession{
+      user_token: "test_user_token",
+      user_id: user_id,
+      storefront: "us"
+    }
+
+    {:ok, %{user_id: user_id, session: session}}
+  end
+
+  describe "start_link/1" do
+    test "starts a new session manager process", %{user_id: user_id, session: session} do
+      assert {:ok, pid} = SessionManager.start_link({user_id, session})
+      assert Process.alive?(pid)
+    end
+
+    test "registers process under {:apple_music, user_id}", %{user_id: user_id, session: session} do
+      {:ok, pid} = SessionManager.start_link({user_id, session})
+      registry_pid = assert_in_registry({:apple_music, user_id})
+      assert registry_pid == pid
+    end
+  end
+
+  describe "get_session/1" do
+    test "returns the stored session", %{user_id: user_id, session: session} do
+      {:ok, _pid} = SessionManager.start_link({user_id, session})
+      assert {:ok, ^session} = SessionManager.get_session(user_id)
+    end
+
+    test "returns :not_found when no process exists", %{user_id: user_id} do
+      assert {:error, :not_found} = SessionManager.get_session(user_id)
+    end
+  end
+
+  describe "stop/1" do
+    test "terminates the process", %{user_id: user_id, session: session} do
+      {:ok, pid} = SessionManager.start_link({user_id, session})
+      assert Process.alive?(pid)
+      assert :ok = SessionManager.stop(user_id)
+      refute Process.alive?(pid)
+    end
+
+    test "returns :not_found when no process exists", %{user_id: user_id} do
+      assert {:error, :not_found} = SessionManager.stop(user_id)
+    end
+  end
+
+  describe "lookup/1" do
+    test "returns {:ok, pid} when process is registered", %{user_id: user_id, session: session} do
+      {:ok, pid} = SessionManager.start_link({user_id, session})
+      assert {:ok, ^pid} = SessionManager.lookup(user_id)
+    end
+
+    test "returns :error when no process is registered", %{user_id: user_id} do
+      assert :error = SessionManager.lookup(user_id)
+    end
+  end
+end

--- a/test/setlistify/apple_music/user_session_test.exs
+++ b/test/setlistify/apple_music/user_session_test.exs
@@ -1,0 +1,35 @@
+defmodule Setlistify.AppleMusic.UserSessionTest do
+  use ExUnit.Case, async: true
+
+  alias Setlistify.AppleMusic.UserSession
+
+  test "creates a valid user session with required fields" do
+    user_id = Ecto.UUID.generate()
+
+    session = %UserSession{
+      user_token: "test_user_token",
+      user_id: user_id,
+      storefront: "us"
+    }
+
+    assert session.user_token == "test_user_token"
+    assert session.user_id == user_id
+    assert session.storefront == "us"
+  end
+
+  test "enforces required keys" do
+    complete_session_map = %{
+      user_token: "test_user_token",
+      user_id: Ecto.UUID.generate(),
+      storefront: "us"
+    }
+
+    for key <- Map.keys(complete_session_map) do
+      session_with_missing_key = Map.delete(complete_session_map, key)
+
+      assert_raise ArgumentError, ~r/the following keys must also be given/, fn ->
+        struct!(UserSession, session_with_missing_key)
+      end
+    end
+  end
+end

--- a/test/setlistify/spotify/session_manager_test.exs
+++ b/test/setlistify/spotify/session_manager_test.exs
@@ -49,7 +49,7 @@ defmodule Setlistify.Spotify.SessionManagerTest do
       }
 
       {:ok, pid} = SessionManager.start_link({user_id, user_session})
-      registry_pid = assert_in_registry(user_id)
+      registry_pid = assert_in_registry({:spotify, user_id})
       assert registry_pid == pid
     end
 
@@ -223,7 +223,7 @@ defmodule Setlistify.Spotify.SessionManagerTest do
         # before the process is registered
         # In this test, we're starting the process after setting up the mock,
         # so we don't want to fail if the process isn't registered yet
-        pid = assert_in_registry(user_id, fail_on_timeout: false)
+        pid = assert_in_registry({:spotify, user_id}, fail_on_timeout: false)
         if is_nil(pid), do: self(), else: pid
       end)
 

--- a/test/setlistify/spotify/session_supervisor_test.exs
+++ b/test/setlistify/spotify/session_supervisor_test.exs
@@ -97,7 +97,7 @@ defmodule Setlistify.Spotify.SessionSupervisorTest do
       # as well.
       Process.sleep(1)
 
-      refute_in_registry(user_id)
+      refute_in_registry({:spotify, user_id})
     end
   end
 

--- a/test/setlistify/user_session_manager_test.exs
+++ b/test/setlistify/user_session_manager_test.exs
@@ -1,0 +1,107 @@
+defmodule Setlistify.UserSessionManagerTest do
+  use ExUnit.Case, async: true
+
+  import Setlistify.Test.RegistryHelpers
+
+  alias Setlistify.UserSessionManager
+  alias Setlistify.Spotify.UserSession, as: SpotifySession
+  alias Setlistify.AppleMusic.UserSession, as: AppleMusicSession
+
+  setup do
+    user_id = unique_user_id()
+
+    spotify_session = %SpotifySession{
+      access_token: "access",
+      refresh_token: "refresh",
+      expires_at: System.system_time(:second) + 3600,
+      user_id: user_id,
+      username: "testuser"
+    }
+
+    apple_music_session = %AppleMusicSession{
+      user_token: "user_token",
+      user_id: user_id,
+      storefront: "us"
+    }
+
+    {:ok,
+     %{
+       user_id: user_id,
+       spotify_session: spotify_session,
+       apple_music_session: apple_music_session
+     }}
+  end
+
+  describe "start/1" do
+    test "routes Spotify session to Spotify.SessionManager", %{
+      user_id: user_id,
+      spotify_session: session
+    } do
+      assert {:ok, _pid} = UserSessionManager.start(session)
+      assert_in_registry({:spotify, user_id})
+    end
+
+    test "routes AppleMusic session to AppleMusic.SessionManager", %{
+      user_id: user_id,
+      apple_music_session: session
+    } do
+      assert {:ok, _pid} = UserSessionManager.start(session)
+      assert_in_registry({:apple_music, user_id})
+    end
+
+    test "registers each provider under its own namespace", %{
+      user_id: user_id,
+      spotify_session: spotify_session,
+      apple_music_session: apple_music_session
+    } do
+      UserSessionManager.start(spotify_session)
+      assert {:ok, _} = UserSessionManager.get_session({:spotify, user_id})
+      assert {:error, :not_found} = UserSessionManager.get_session({:apple_music, user_id})
+
+      UserSessionManager.start(apple_music_session)
+      assert {:ok, _} = UserSessionManager.get_session({:apple_music, user_id})
+    end
+  end
+
+  describe "get_session/1" do
+    test "returns the session for the correct provider", %{
+      user_id: user_id,
+      spotify_session: spotify_session,
+      apple_music_session: apple_music_session
+    } do
+      UserSessionManager.start(spotify_session)
+      UserSessionManager.start(apple_music_session)
+
+      assert {:ok, ^spotify_session} = UserSessionManager.get_session({:spotify, user_id})
+      assert {:ok, ^apple_music_session} = UserSessionManager.get_session({:apple_music, user_id})
+    end
+
+    test "returns :not_found when no session exists" do
+      assert {:error, :not_found} =
+               UserSessionManager.get_session({:spotify, unique_user_id()})
+
+      assert {:error, :not_found} =
+               UserSessionManager.get_session({:apple_music, unique_user_id()})
+    end
+  end
+
+  describe "stop/1" do
+    test "terminates the session process", %{
+      user_id: user_id,
+      spotify_session: spotify_session,
+      apple_music_session: apple_music_session
+    } do
+      for {key, session} <- [{:spotify, spotify_session}, {:apple_music, apple_music_session}] do
+        {:ok, pid} = UserSessionManager.start(session)
+        assert Process.alive?(pid)
+        assert :ok = UserSessionManager.stop({key, user_id})
+        refute Process.alive?(pid)
+      end
+    end
+
+    test "returns :not_found when no session exists" do
+      assert {:error, :not_found} = UserSessionManager.stop({:spotify, unique_user_id()})
+      assert {:error, :not_found} = UserSessionManager.stop({:apple_music, unique_user_id()})
+    end
+  end
+end

--- a/test/setlistify_web/controllers/oauth_callback_controller_test.exs
+++ b/test/setlistify_web/controllers/oauth_callback_controller_test.exs
@@ -138,7 +138,7 @@ defmodule SetlistifyWeb.OAuthCallbackControllerTest do
       # Check that user was removed from the session
 
       # Check that process was removed from registry
-      refute_in_registry(test_user)
+      refute_in_registry({:spotify, test_user})
     end
 
     test "successful callback with redirect_to redirects to provided path", %{

--- a/test/setlistify_web/controllers/oauth_callback_session_test.exs
+++ b/test/setlistify_web/controllers/oauth_callback_session_test.exs
@@ -50,7 +50,7 @@ defmodule SetlistifyWeb.OAuthCallbackSessionTest do
       refute get_session(conn, "account_name")
 
       # Verify SessionManager was started with the user session
-      assert_in_registry(user_id)
+      assert_in_registry({:spotify, user_id})
 
       # Verify redirect happened
       assert conn.status == 302

--- a/test/setlistify_web/controllers/oauth_flow_test.exs
+++ b/test/setlistify_web/controllers/oauth_flow_test.exs
@@ -78,7 +78,7 @@ defmodule SetlistifyWeb.OAuthFlowTest do
       signout_response = get(signout_conn, ~p"/signout")
 
       # Session process should be stopped
-      refute_in_registry(test_user)
+      refute_in_registry({:spotify, test_user})
 
       # Session should be cleared
       refute get_session(signout_response, :refresh_token)

--- a/test/setlistify_web/plugs/restore_spotify_token_test.exs
+++ b/test/setlistify_web/plugs/restore_spotify_token_test.exs
@@ -80,7 +80,7 @@ defmodule SetlistifyWeb.Plugs.RestoreSpotifyTokenTest do
 
       # Allow the mock to be called from the session process
       allow(Setlistify.Spotify.API.MockClient, self(), fn ->
-        pid = assert_in_registry(user_id, fail_on_timeout: false)
+        pid = assert_in_registry({:spotify, user_id}, fail_on_timeout: false)
         if is_nil(pid), do: self(), else: pid
       end)
 
@@ -114,12 +114,12 @@ defmodule SetlistifyWeb.Plugs.RestoreSpotifyTokenTest do
 
       # Allow the mock to be called from the session process
       allow(Setlistify.Spotify.API.MockClient, self(), fn ->
-        pid = assert_in_registry(user_id, fail_on_timeout: false)
+        pid = assert_in_registry({:spotify, user_id}, fail_on_timeout: false)
         if is_nil(pid), do: self(), else: pid
       end)
 
       # Ensure there is no existing token process
-      refute_in_registry(user_id)
+      refute_in_registry({:spotify, user_id})
 
       conn =
         conn

--- a/test/support/registry_helpers.ex
+++ b/test/support/registry_helpers.ex
@@ -4,7 +4,7 @@ defmodule Setlistify.Test.RegistryHelpers do
   """
 
   @doc """
-  Asserts that a process is registered with the Registry for the given user_id.
+  Asserts that a process is registered with the Registry for the given provider key.
 
   Waits for the process to be registered, retrying up to max_attempts times with
   sleep_ms milliseconds between attempts. If the process is not registered after
@@ -23,26 +23,19 @@ defmodule Setlistify.Test.RegistryHelpers do
 
   ## Examples
 
-  # Assert that a process is registered for "user_123"
-  pid = assert_in_registry("user_123")
-
-  # Wait longer with more attempts
-  pid = assert_in_registry("user_123", max_attempts: 20, sleep_ms: 100)
-
-  # Don't fail if not found (e.g., when testing process creation)
-  pid = assert_in_registry("user_123", fail_on_timeout: false)
-  if is_nil(pid), do: handle_not_found()
+      pid = assert_in_registry({:spotify, "user_123"})
+      pid = assert_in_registry({:apple_music, "user_123"}, max_attempts: 20, sleep_ms: 100)
+      pid = assert_in_registry({:spotify, "user_123"}, fail_on_timeout: false)
   """
-  def assert_in_registry(user_id, opts \\ []) do
+  def assert_in_registry({provider, user_id}, opts \\ []) do
     max_attempts = Keyword.get(opts, :max_attempts, 3)
     sleep_ms = Keyword.get(opts, :sleep_ms, 1)
     fail_on_timeout = Keyword.get(opts, :fail_on_timeout, true)
 
-    # Import ExUnit.Assertions for flunk
     import ExUnit.Assertions, only: [flunk: 1]
 
     Enum.reduce_while(1..max_attempts, nil, fn attempt, _ ->
-      case Registry.lookup(Setlistify.UserSessionRegistry, {:spotify, user_id}) do
+      case Registry.lookup(Setlistify.UserSessionRegistry, {provider, user_id}) do
         [{pid, _}] ->
           {:halt, pid}
 
@@ -53,7 +46,7 @@ defmodule Setlistify.Test.RegistryHelpers do
           else
             if fail_on_timeout do
               flunk(
-                "Timed out waiting for process to be registered for user_id: #{user_id} after #{max_attempts} attempts"
+                "Timed out waiting for process to be registered for #{provider} user_id: #{user_id} after #{max_attempts} attempts"
               )
             else
               {:halt, nil}
@@ -64,7 +57,7 @@ defmodule Setlistify.Test.RegistryHelpers do
   end
 
   @doc """
-  Refutes that a process is registered with the Registry for the given user_id.
+  Refutes that a process is registered with the Registry for the given provider key.
 
   Waits for the process to be unregistered, retrying up to max_attempts times with
   sleep_ms milliseconds between attempts. If the process is still registered after
@@ -83,26 +76,18 @@ defmodule Setlistify.Test.RegistryHelpers do
 
   ## Examples
 
-  # Refute that a process is registered for "user_123"
-  refute_in_registry("user_123")
-
-  # Wait longer with more attempts
-  refute_in_registry("user_123", max_attempts: 20, sleep_ms: 100)
-
-  # Don't fail if still found (e.g., when testing process shutdown)
-  result = refute_in_registry("user_123", fail_on_timeout: false)
-  if is_pid(result), do: handle_still_exists(result)
+      refute_in_registry({:spotify, "user_123"})
+      refute_in_registry({:apple_music, "user_123"}, max_attempts: 20, sleep_ms: 100)
   """
-  def refute_in_registry(user_id, opts \\ []) do
+  def refute_in_registry({provider, user_id}, opts \\ []) do
     max_attempts = Keyword.get(opts, :max_attempts, 3)
     sleep_ms = Keyword.get(opts, :sleep_ms, 1)
     fail_on_timeout = Keyword.get(opts, :fail_on_timeout, true)
 
-    # Import ExUnit.Assertions for flunk
     import ExUnit.Assertions, only: [flunk: 1]
 
     Enum.reduce_while(1..max_attempts, nil, fn attempt, _ ->
-      case Registry.lookup(Setlistify.UserSessionRegistry, {:spotify, user_id}) do
+      case Registry.lookup(Setlistify.UserSessionRegistry, {provider, user_id}) do
         [] ->
           {:halt, true}
 
@@ -113,7 +98,7 @@ defmodule Setlistify.Test.RegistryHelpers do
           else
             if fail_on_timeout do
               flunk(
-                "Failed refutation: Process is still registered for user_id: #{user_id} after #{max_attempts} attempts"
+                "Failed refutation: Process is still registered for #{provider} user_id: #{user_id} after #{max_attempts} attempts"
               )
             else
               {:halt, pid}
@@ -130,7 +115,7 @@ defmodule Setlistify.Test.RegistryHelpers do
 
   ## Example
 
-  user_id = unique_user_id()
+      user_id = unique_user_id()
   """
   def unique_user_id, do: "user_#{System.unique_integer([:positive])}"
 end


### PR DESCRIPTION
## Summary

- Adds `AppleMusic.UserSession` struct (`user_token`, `user_id`, `storefront` — no `username`, Apple has no profile endpoint)
- Adds `AppleMusic.SessionManager` — simplified GenServer with no refresh timer, structurally encoding the ~6 month token lifetime
- Adds `Setlistify.UserSessionManager` dispatch module mirroring the `MusicService.API` pattern: `impl/1` routes by session struct type (for `start`) or provider key tuple (for `get_session`/`stop`). Two dispatch patterns are needed because session creation has the struct in hand, while lookups and teardown only have the provider + user ID from the session cookie
- Adds `@behaviour Setlistify.UserSessionManager` to both `Spotify.SessionManager` and `AppleMusic.SessionManager` for Dialyzer enforcement
- Updates `RegistryHelpers` to take a `{provider, user_id}` tuple (e.g. `assert_in_registry({:spotify, user_id})`) consistent with the registry key format used throughout the system

## Test plan

- [ ] `mix test` passes (180 tests, 0 failures)
- [ ] No manual testing available at this stage — nothing in the web layer calls into this infrastructure yet. That wiring comes with `RestoreAppleMusicToken`, the sign-in handler, and `AppleMusic.API`

## Part of

Phase 3 of [ADR-003: Apple Music Integration](docs/adrs/003-apple-music-integration.md)

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)