### PR TITLE
test: suppress expected error logs in error-path tests

### DIFF
--- a/test/setlistify/setlist_fm/api/external_client_test.exs
+++ b/test/setlistify/setlist_fm/api/external_client_test.exs
@@ -483,6 +483,7 @@ defmodule Setlistify.SetlistFm.API.ExternalClientTest do
       assert {:error, {:api_error, "HTTP 429"}} = ExternalClient.search("test artist", 1)
     end
 
+    @tag :capture_log
     test "search/2 returns error tuple on network failure" do
       Req.Test.expect(MySetlistFmStub, fn
         %{request_path: "/rest/1.0/search/setlists", method: "GET"} = _conn ->

--- a/test/setlistify/spotify/api/external_client_test.exs
+++ b/test/setlistify/spotify/api/external_client_test.exs
@@ -231,18 +231,21 @@ defmodule Setlistify.Spotify.Api.ExternalClientTest do
       assert tokens.expires_in == 3600
     end
 
+    @tag :capture_log
     test "returns error on invalid token" do
       Req.Test.expect(MySpotifyStub, fn conn -> Plug.Conn.send_resp(conn, 401, "Unauthorized") end)
 
       assert {:error, :invalid_token} = ExternalClient.refresh_token("invalid_token")
     end
 
+    @tag :capture_log
     test "returns error on bad request" do
       Req.Test.expect(MySpotifyStub, fn conn -> Plug.Conn.send_resp(conn, 400, "Bad Request") end)
 
       assert {:error, :invalid_token} = ExternalClient.refresh_token("bad_token")
     end
 
+    @tag :capture_log
     test "returns error on server error" do
       Req.Test.expect(MySpotifyStub, fn conn ->
         Plug.Conn.send_resp(conn, 500, "Internal Server Error")


### PR DESCRIPTION
## Summary

- Add `@tag :capture_log` to tests that intentionally trigger error states (400, 401, 500 token refresh failures and setlist.fm network failure)
- Eliminates 4 noisy error log lines from `mix test` output without changing any test assertions

## Test plan

- [ ] `mix test` passes with no error log output

🤖 Generated with [Claude Code](https://claude.com/claude-code)