### PR TITLE
refactor: consolidate OTel attribute-setting into MusicService.API

### DIFF
--- a/lib/setlistify/apple_music/api.ex
+++ b/lib/setlistify/apple_music/api.ex
@@ -19,59 +19,28 @@ defmodule Setlistify.AppleMusic.API do
   @callback search_for_track(UserSession.t(), String.t(), String.t()) ::
               nil | %{track_id: String.t()}
   def search_for_track(user_session, artist, track) do
-    OpenTelemetry.Tracer.with_span "Setlistify.AppleMusic.API.search_for_track" do
-      OpenTelemetry.Tracer.set_attributes([
-        {"peer.service", "apple_music"},
-        {"music.artist", artist},
-        {"music.track", track},
-        {"user.id", user_session.user_id},
-        {"enduser.id", user_session.user_id}
-      ])
+    parent_ctx = OpenTelemetry.Ctx.get_current()
+    parent_span = OpenTelemetry.Tracer.current_span_ctx(parent_ctx)
 
-      parent_ctx = OpenTelemetry.Ctx.get_current()
-      parent_span = OpenTelemetry.Tracer.current_span_ctx(parent_ctx)
+    :apple_music_track_cache
+    |> Cachex.fetch({artist, track}, fn {artist, track} ->
+      OpenTelemetry.Ctx.attach(parent_ctx)
+      OpenTelemetry.Tracer.set_current_span(parent_span)
 
-      :apple_music_track_cache
-      |> Cachex.fetch({artist, track}, fn {artist, track} ->
-        OpenTelemetry.Ctx.attach(parent_ctx)
-        OpenTelemetry.Tracer.set_current_span(parent_span)
-
-        impl().search_for_track(user_session, artist, track)
-      end)
-      |> elem(1)
-    end
+      impl().search_for_track(user_session, artist, track)
+    end)
+    |> elem(1)
   end
 
   @callback create_playlist(UserSession.t(), String.t(), String.t()) ::
               {:ok, %{id: String.t(), external_url: String.t()}} | {:error, atom()}
-  def create_playlist(user_session, name, description) do
-    OpenTelemetry.Tracer.with_span "Setlistify.AppleMusic.API.create_playlist" do
-      OpenTelemetry.Tracer.set_attributes([
-        {"peer.service", "apple_music"},
-        {"playlist.name", name},
-        {"user.id", user_session.user_id},
-        {"enduser.id", user_session.user_id}
-      ])
-
-      impl().create_playlist(user_session, name, description)
-    end
-  end
+  def create_playlist(user_session, name, description),
+    do: impl().create_playlist(user_session, name, description)
 
   @callback add_tracks_to_playlist(UserSession.t(), String.t(), [String.t()]) ::
               {:ok, atom()} | {:error, atom()}
-  def add_tracks_to_playlist(user_session, playlist_id, tracks) do
-    OpenTelemetry.Tracer.with_span "Setlistify.AppleMusic.API.add_tracks_to_playlist" do
-      OpenTelemetry.Tracer.set_attributes([
-        {"peer.service", "apple_music"},
-        {"playlist.id", playlist_id},
-        {"tracks.count", length(tracks)},
-        {"user.id", user_session.user_id},
-        {"enduser.id", user_session.user_id}
-      ])
-
-      impl().add_tracks_to_playlist(user_session, playlist_id, tracks)
-    end
-  end
+  def add_tracks_to_playlist(user_session, playlist_id, tracks),
+    do: impl().add_tracks_to_playlist(user_session, playlist_id, tracks)
 
   defp impl do
     Application.get_env(

--- a/lib/setlistify/music_service/api.ex
+++ b/lib/setlistify/music_service/api.ex
@@ -4,9 +4,6 @@ defmodule Setlistify.MusicService.API do
 
   Dispatch is based on the type of the user_session struct, so callers do not
   need to reference a specific provider (e.g. Spotify) directly.
-
-  This module opens OTel spans and sets all shared attributes for each operation,
-  including `peer.service` (set by `impl/1` as a side effect of provider dispatch).
   """
 
   require OpenTelemetry.Tracer

--- a/lib/setlistify/music_service/api.ex
+++ b/lib/setlistify/music_service/api.ex
@@ -5,9 +5,8 @@ defmodule Setlistify.MusicService.API do
   Dispatch is based on the type of the user_session struct, so callers do not
   need to reference a specific provider (e.g. Spotify) directly.
 
-  This module opens OTel spans and sets shared attributes for each operation.
-  Provider modules (`Spotify.API`, `AppleMusic.API`) add only their own
-  `peer.service` attribute to the current span before delegating to `impl()`.
+  This module opens OTel spans and sets all shared attributes for each operation,
+  including `peer.service` (set by `impl/1` as a side effect of provider dispatch).
   """
 
   require OpenTelemetry.Tracer

--- a/lib/setlistify/music_service/api.ex
+++ b/lib/setlistify/music_service/api.ex
@@ -4,7 +4,13 @@ defmodule Setlistify.MusicService.API do
 
   Dispatch is based on the type of the user_session struct, so callers do not
   need to reference a specific provider (e.g. Spotify) directly.
+
+  This module opens OTel spans and sets shared attributes for each operation.
+  Provider modules (`Spotify.API`, `AppleMusic.API`) add only their own
+  `peer.service` attribute to the current span before delegating to `impl()`.
   """
+
+  require OpenTelemetry.Tracer
 
   alias Setlistify.{AppleMusic, Spotify}
 
@@ -19,17 +25,53 @@ defmodule Setlistify.MusicService.API do
   @callback add_tracks_to_playlist(user_session(), String.t(), [String.t()]) ::
               {:ok, atom()} | {:error, atom()}
 
-  defp impl(%Spotify.UserSession{}), do: Spotify.API
-  defp impl(%AppleMusic.UserSession{}), do: AppleMusic.API
+  defp impl(%Spotify.UserSession{}) do
+    OpenTelemetry.Tracer.set_attribute("peer.service", "spotify")
+    Spotify.API
+  end
 
-  def search_for_track(user_session, artist, track),
-    do: impl(user_session).search_for_track(user_session, artist, track)
+  defp impl(%AppleMusic.UserSession{}) do
+    OpenTelemetry.Tracer.set_attribute("peer.service", "apple_music")
+    AppleMusic.API
+  end
 
-  def create_playlist(user_session, name, description),
-    do: impl(user_session).create_playlist(user_session, name, description)
+  def search_for_track(user_session, artist, track) do
+    OpenTelemetry.Tracer.with_span "Setlistify.MusicService.API.search_for_track" do
+      OpenTelemetry.Tracer.set_attributes([
+        {"user.id", user_session.user_id},
+        {"enduser.id", user_session.user_id},
+        {"music.artist", artist},
+        {"music.track", track}
+      ])
 
-  def add_tracks_to_playlist(user_session, playlist_id, tracks),
-    do: impl(user_session).add_tracks_to_playlist(user_session, playlist_id, tracks)
+      impl(user_session).search_for_track(user_session, artist, track)
+    end
+  end
+
+  def create_playlist(user_session, name, description) do
+    OpenTelemetry.Tracer.with_span "Setlistify.MusicService.API.create_playlist" do
+      OpenTelemetry.Tracer.set_attributes([
+        {"user.id", user_session.user_id},
+        {"enduser.id", user_session.user_id},
+        {"playlist.name", name}
+      ])
+
+      impl(user_session).create_playlist(user_session, name, description)
+    end
+  end
+
+  def add_tracks_to_playlist(user_session, playlist_id, tracks) do
+    OpenTelemetry.Tracer.with_span "Setlistify.MusicService.API.add_tracks_to_playlist" do
+      OpenTelemetry.Tracer.set_attributes([
+        {"user.id", user_session.user_id},
+        {"enduser.id", user_session.user_id},
+        {"playlist.id", playlist_id},
+        {"tracks.count", length(tracks)}
+      ])
+
+      impl(user_session).add_tracks_to_playlist(user_session, playlist_id, tracks)
+    end
+  end
 
   def get_embed("spotify", url), do: Spotify.API.get_embed(url)
 end

--- a/lib/setlistify/spotify/api.ex
+++ b/lib/setlistify/spotify/api.ex
@@ -9,61 +9,30 @@ defmodule Setlistify.Spotify.API do
   @callback search_for_track(UserSession.t(), String.t(), String.t()) ::
               nil | %{track_id: String.t()}
   def search_for_track(user_session, artist, track) do
-    OpenTelemetry.Tracer.with_span "Setlistify.Spotify.API.search_for_track" do
-      OpenTelemetry.Tracer.set_attributes([
-        {"peer.service", "spotify"},
-        {"music.artist", artist},
-        {"music.track", track},
-        {"user.id", user_session.user_id},
-        {"enduser.id", user_session.user_id}
-      ])
+    # Cachex uses a separate process, so we need to propogate OpenTelemetry context
+    # TODO: If we do this enough we should consider making a helper
+    parent_ctx = OpenTelemetry.Ctx.get_current()
+    parent_span = OpenTelemetry.Tracer.current_span_ctx(parent_ctx)
 
-      # Cachex uses a separate process, so we need to propogate OpenTelemetry context
-      # TODO: If we do this enough we should consider making a helper
-      parent_ctx = OpenTelemetry.Ctx.get_current()
-      parent_span = OpenTelemetry.Tracer.current_span_ctx(parent_ctx)
+    :spotify_track_cache
+    |> Cachex.fetch({artist, track}, fn {artist, track} ->
+      OpenTelemetry.Ctx.attach(parent_ctx)
+      OpenTelemetry.Tracer.set_current_span(parent_span)
 
-      :spotify_track_cache
-      |> Cachex.fetch({artist, track}, fn {artist, track} ->
-        OpenTelemetry.Ctx.attach(parent_ctx)
-        OpenTelemetry.Tracer.set_current_span(parent_span)
-
-        impl().search_for_track(user_session, artist, track)
-      end)
-      |> elem(1)
-    end
+      impl().search_for_track(user_session, artist, track)
+    end)
+    |> elem(1)
   end
 
   @callback create_playlist(UserSession.t(), String.t(), String.t()) ::
               {:ok, %{id: String.t(), external_url: String.t()}} | {:error, atom()}
-  def create_playlist(user_session, name, description) do
-    OpenTelemetry.Tracer.with_span "Setlistify.Spotify.API.create_playlist" do
-      OpenTelemetry.Tracer.set_attributes([
-        {"peer.service", "spotify"},
-        {"playlist.name", name},
-        {"user.id", user_session.user_id},
-        {"enduser.id", user_session.user_id}
-      ])
-
-      impl().create_playlist(user_session, name, description)
-    end
-  end
+  def create_playlist(user_session, name, description),
+    do: impl().create_playlist(user_session, name, description)
 
   @callback add_tracks_to_playlist(UserSession.t(), String.t(), [String.t()]) ::
               {:ok, atom()} | {:error, atom()}
-  def add_tracks_to_playlist(user_session, playlist_id, tracks) do
-    OpenTelemetry.Tracer.with_span "Setlistify.Spotify.API.add_tracks_to_playlist" do
-      OpenTelemetry.Tracer.set_attributes([
-        {"peer.service", "spotify"},
-        {"playlist.id", playlist_id},
-        {"tracks.count", length(tracks)},
-        {"user.id", user_session.user_id},
-        {"enduser.id", user_session.user_id}
-      ])
-
-      impl().add_tracks_to_playlist(user_session, playlist_id, tracks)
-    end
-  end
+  def add_tracks_to_playlist(user_session, playlist_id, tracks),
+    do: impl().add_tracks_to_playlist(user_session, playlist_id, tracks)
 
   @callback get_embed(String.t()) :: {:ok, String.t()} | {:error, atom()}
   def get_embed(url) do


### PR DESCRIPTION
## Summary

- `MusicService.API` now opens OTel spans and sets all shared attributes (`user.id`, `enduser.id`, plus operation-specific ones) for `search_for_track`, `create_playlist`, and `add_tracks_to_playlist`
- `impl/1` sets `peer.service` as a side effect of resolving the provider — it already pattern-matches on the session struct type, so it's the natural place for this
- `Spotify.API` and `AppleMusic.API` shared operation functions are now pure delegations with no OTel boilerplate

Closes #71 (partial — addresses the API OTel consolidation identified as the strongest extraction candidate)

## Test plan

- [x] `mix test` — 208 tests, 0 failures
- [x] `mix format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)