### PR TITLE
refactor: clean up OTel and error handling in ExternalClients

### DIFF
--- a/lib/setlistify/apple_music/api/external_client.ex
+++ b/lib/setlistify/apple_music/api/external_client.ex
@@ -105,13 +105,6 @@ defmodule Setlistify.AppleMusic.API.ExternalClient do
 
   def create_playlist(user_session, name, description) do
     OpenTelemetry.Tracer.with_span "Setlistify.AppleMusic.API.ExternalClient.create_playlist" do
-      OpenTelemetry.Tracer.set_attributes([
-        {"peer.service", "apple_music"},
-        {"playlist.name", name},
-        {"user.id", user_session.user_id},
-        {"enduser.id", user_session.user_id}
-      ])
-
       Logger.info("Creating playlist", %{name: name, user_id: user_session.user_id})
 
       request_fn = fn req ->
@@ -167,14 +160,6 @@ defmodule Setlistify.AppleMusic.API.ExternalClient do
 
   def add_tracks_to_playlist(user_session, playlist_id, tracks) do
     OpenTelemetry.Tracer.with_span "Setlistify.AppleMusic.API.ExternalClient.add_tracks_to_playlist" do
-      OpenTelemetry.Tracer.set_attributes([
-        {"peer.service", "apple_music"},
-        {"playlist.id", playlist_id},
-        {"tracks.count", length(tracks)},
-        {"user.id", user_session.user_id},
-        {"enduser.id", user_session.user_id}
-      ])
-
       Logger.info("Adding tracks to playlist", %{
         playlist_id: playlist_id,
         track_count: length(tracks),

--- a/lib/setlistify/apple_music/api/external_client.ex
+++ b/lib/setlistify/apple_music/api/external_client.ex
@@ -31,16 +31,21 @@ defmodule Setlistify.AppleMusic.API.ExternalClient do
     case request_fn.(req) do
       {:ok, %{status: 401}} ->
         Logger.warning("401 during #{context}, regenerating developer token and retrying")
-        DeveloperTokenManager.regenerate_token()
-        new_req = client(user_session)
 
-        case request_fn.(new_req) do
-          {:ok, %{status: 401}} ->
-            Logger.error("Unauthorized during #{context} for user_id #{user_session.user_id}")
-            {:error, :unauthorized}
+        OpenTelemetry.Tracer.with_span "developer_token_refresh_retry" do
+          DeveloperTokenManager.regenerate_token()
+          new_req = client(user_session)
 
-          other ->
-            other
+          case request_fn.(new_req) do
+            {:ok, %{status: 401}} ->
+              Logger.error("Unauthorized during #{context} for user_id #{user_session.user_id}")
+              OpenTelemetry.Tracer.set_status(:error, "Unauthorized after token regeneration")
+              {:error, :unauthorized}
+
+            other ->
+              OpenTelemetry.Tracer.set_status(:ok, "")
+              other
+          end
         end
 
       other ->

--- a/lib/setlistify/apple_music/api/external_client.ex
+++ b/lib/setlistify/apple_music/api/external_client.ex
@@ -38,7 +38,11 @@ defmodule Setlistify.AppleMusic.API.ExternalClient do
 
           case request_fn.(new_req) do
             {:ok, %{status: 401}} ->
-              Logger.error("Unauthorized during #{context} for user_id #{user_session.user_id}")
+              Logger.error(
+                "Received 401 after developer token regeneration during #{context} — will not retry",
+                %{user_id: user_session.user_id}
+              )
+
               OpenTelemetry.Tracer.set_status(:error, "Unauthorized after token regeneration")
               {:error, :unauthorized}
 

--- a/lib/setlistify/apple_music/api/external_client.ex
+++ b/lib/setlistify/apple_music/api/external_client.ex
@@ -35,8 +35,12 @@ defmodule Setlistify.AppleMusic.API.ExternalClient do
         new_req = client(user_session)
 
         case request_fn.(new_req) do
-          {:ok, %{status: 401}} -> {:error, :unauthorized}
-          other -> other
+          {:ok, %{status: 401}} ->
+            Logger.error("Unauthorized during #{context} for user_id #{user_session.user_id}")
+            {:error, :unauthorized}
+
+          other ->
+            other
         end
 
       other ->
@@ -79,14 +83,8 @@ defmodule Setlistify.AppleMusic.API.ExternalClient do
               %{track_id: song["id"]}
           end
 
-        {:error, :unauthorized} = error ->
-          Logger.error("Unauthorized search request for user_id #{user_session.user_id}")
-          OpenTelemetry.Tracer.set_status(:error, "Unauthorized")
-          error
-
         {:error, reason} = error ->
-          Logger.error("Search failed", %{artist: artist, track: track, error: reason})
-          OpenTelemetry.Tracer.set_status(:error, "Search failed: #{inspect(reason)}")
+          OpenTelemetry.Tracer.set_status(:error, inspect(reason))
           error
 
         {:ok, response} ->
@@ -133,14 +131,8 @@ defmodule Setlistify.AppleMusic.API.ExternalClient do
 
           {:ok, %{id: playlist_id, external_url: external_url}}
 
-        {:error, :unauthorized} = error ->
-          Logger.error("Unauthorized playlist creation for user_id #{user_session.user_id}")
-          OpenTelemetry.Tracer.set_status(:error, "Unauthorized")
-          error
-
         {:error, reason} = error ->
-          Logger.error("Failed to create playlist", %{name: name, error: reason})
-          OpenTelemetry.Tracer.set_status(:error, "Creation failed: #{inspect(reason)}")
+          OpenTelemetry.Tracer.set_status(:error, inspect(reason))
           error
 
         {:ok, response} ->
@@ -185,14 +177,8 @@ defmodule Setlistify.AppleMusic.API.ExternalClient do
           OpenTelemetry.Tracer.set_status(:ok, "")
           {:ok, :tracks_added}
 
-        {:error, :unauthorized} = error ->
-          Logger.error("Unauthorized adding tracks for user_id #{user_session.user_id}")
-          OpenTelemetry.Tracer.set_status(:error, "Unauthorized")
-          error
-
         {:error, reason} = error ->
-          Logger.error("Failed to add tracks", %{playlist_id: playlist_id, error: reason})
-          OpenTelemetry.Tracer.set_status(:error, "Addition failed: #{inspect(reason)}")
+          OpenTelemetry.Tracer.set_status(:error, inspect(reason))
           error
 
         {:ok, response} ->

--- a/lib/setlistify/apple_music/api/external_client.ex
+++ b/lib/setlistify/apple_music/api/external_client.ex
@@ -32,7 +32,7 @@ defmodule Setlistify.AppleMusic.API.ExternalClient do
       {:ok, %{status: 401}} ->
         Logger.warning("401 during #{context}, regenerating developer token and retrying")
 
-        OpenTelemetry.Tracer.with_span "developer_token_refresh_retry" do
+        OpenTelemetry.Tracer.with_span "Setlistify.AppleMusic.API.ExternalClient.with_developer_token_refresh" do
           DeveloperTokenManager.regenerate_token()
           new_req = client(user_session)
 

--- a/lib/setlistify/spotify/api/external_client.ex
+++ b/lib/setlistify/spotify/api/external_client.ex
@@ -43,20 +43,27 @@ defmodule Setlistify.Spotify.API.ExternalClient do
             "Token expired during #{context}, attempting to refresh for user_id: #{user_session.user_id}"
           )
 
-          # Attempt to refresh the token
-          case SessionManager.refresh_session(user_session.user_id) do
-            {:ok, new_session} ->
-              Logger.debug("Successfully refreshed token during #{context}, retrying request")
-              # Create new client and retry the request
-              new_req = client(new_session)
-              request_fn.(new_req)
+          OpenTelemetry.Tracer.with_span "session_token_refresh_retry" do
+            case SessionManager.refresh_session(user_session.user_id) do
+              {:ok, new_session} ->
+                Logger.debug("Successfully refreshed token during #{context}, retrying request")
+                new_req = client(new_session)
+                result = request_fn.(new_req)
+                OpenTelemetry.Tracer.set_status(:ok, "")
+                result
 
-            {:error, reason} ->
-              Logger.error(
-                "Failed to refresh token during #{context} for user_id #{user_session.user_id}: #{inspect(reason)}"
-              )
+              {:error, reason} ->
+                Logger.error(
+                  "Failed to refresh token during #{context} for user_id #{user_session.user_id}: #{inspect(reason)}"
+                )
 
-              {:error, :token_refresh_failed}
+                OpenTelemetry.Tracer.set_status(
+                  :error,
+                  "Token refresh failed: #{inspect(reason)}"
+                )
+
+                {:error, :token_refresh_failed}
+            end
           end
         else
           # Non-token 401 error, just pass it through
@@ -104,13 +111,7 @@ defmodule Setlistify.Spotify.API.ExternalClient do
           result
 
         {:error, reason} = error ->
-          Logger.error("Search failed", %{
-            artist: artist,
-            track: track,
-            error: reason
-          })
-
-          OpenTelemetry.Tracer.set_status(:error, "Search failed: #{inspect(reason)}")
+          OpenTelemetry.Tracer.set_status(:error, inspect(reason))
           error
 
         {:ok, %{status: 401} = response} ->
@@ -183,12 +184,7 @@ defmodule Setlistify.Spotify.API.ExternalClient do
           {:error, :playlist_creation_failed}
 
         {:error, reason} = error ->
-          Logger.error("Failed to create playlist", %{
-            name: name,
-            error: reason
-          })
-
-          OpenTelemetry.Tracer.set_status(:error, "Creation failed: #{inspect(reason)}")
+          OpenTelemetry.Tracer.set_status(:error, inspect(reason))
           error
       end
     end
@@ -227,12 +223,7 @@ defmodule Setlistify.Spotify.API.ExternalClient do
           {:error, :tracks_addition_failed}
 
         {:error, reason} = error ->
-          Logger.error("Failed to add tracks", %{
-            playlist_id: playlist_id,
-            error: reason
-          })
-
-          OpenTelemetry.Tracer.set_status(:error, "Addition failed: #{inspect(reason)}")
+          OpenTelemetry.Tracer.set_status(:error, inspect(reason))
           error
       end
     end

--- a/lib/setlistify/spotify/api/external_client.ex
+++ b/lib/setlistify/spotify/api/external_client.ex
@@ -43,7 +43,7 @@ defmodule Setlistify.Spotify.API.ExternalClient do
             "Token expired during #{context}, attempting to refresh for user_id: #{user_session.user_id}"
           )
 
-          OpenTelemetry.Tracer.with_span "session_token_refresh_retry" do
+          OpenTelemetry.Tracer.with_span "Setlistify.Spotify.API.ExternalClient.with_token_refresh" do
             case SessionManager.refresh_session(user_session.user_id) do
               {:ok, new_session} ->
                 Logger.debug("Successfully refreshed token during #{context}, retrying request")

--- a/lib/setlistify/spotify/api/external_client.ex
+++ b/lib/setlistify/spotify/api/external_client.ex
@@ -137,13 +137,6 @@ defmodule Setlistify.Spotify.API.ExternalClient do
 
   def create_playlist(user_session, name, description) do
     OpenTelemetry.Tracer.with_span "Setlistify.Spotify.API.ExternalClient.create_playlist" do
-      OpenTelemetry.Tracer.set_attributes([
-        {"peer.service", "spotify"},
-        {"playlist.name", name},
-        {"user.id", user_session.user_id},
-        {"enduser.id", user_session.user_id}
-      ])
-
       Logger.info("Creating playlist", %{
         name: name,
         user_id: user_session.user_id
@@ -205,14 +198,6 @@ defmodule Setlistify.Spotify.API.ExternalClient do
 
   def add_tracks_to_playlist(user_session, playlist_id, tracks) do
     OpenTelemetry.Tracer.with_span "Setlistify.Spotify.API.ExternalClient.add_tracks_to_playlist" do
-      OpenTelemetry.Tracer.set_attributes([
-        {"peer.service", "spotify"},
-        {"playlist.id", playlist_id},
-        {"tracks.count", length(tracks)},
-        {"user.id", user_session.user_id},
-        {"enduser.id", user_session.user_id}
-      ])
-
       Logger.info("Adding tracks to playlist", %{
         playlist_id: playlist_id,
         track_count: length(tracks),


### PR DESCRIPTION
## Summary

Follow-up to #89, which moved shared OTel attribute-setting into `MusicService.API`.

- Remove upfront attributes (`peer.service`, `user.id`, `enduser.id`, operation parameters) from `create_playlist` and `add_tracks_to_playlist` in both ExternalClients — these are already set on the parent `MusicService.API` span. ExternalClient spans now only set response-derived attributes (`results.count`, `track.id`, `playlist.id`, `playlist.url`), consistent with how `search_for_track` already worked
- Consolidate error handling in both ExternalClients: move `:unauthorized` logging into the retry helpers (which are the only source of that error), collapse redundant per-operation error branches at call sites to a single `{:error, reason}` clause that sets OTel status
- Add a child span around the token refresh + retry block in both `with_developer_token_refresh` and `with_token_refresh`, so traces show regeneration timing separately and carry their own error status if the retry fails

Closes #71

## Test plan

- [x] `mix test` — 208 tests, 0 failures
- [x] `mix format` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)