### PR TITLE
Update unauthenticated setlist view to be service-agnostic

### DIFF
--- a/lib/setlistify_web/components/layouts/app.html.heex
+++ b/lib/setlistify_web/components/layouts/app.html.heex
@@ -92,7 +92,7 @@
 <footer class="border-t border-gray-800 py-6 px-4 text-center">
   <div class="max-w-6xl mx-auto">
     <p class="text-sm text-gray-500">
-      © {Date.utc_today().year} Setlistify • Not affiliated with Spotify
+      © {Date.utc_today().year} Setlistify
     </p>
   </div>
 </footer>

--- a/lib/setlistify_web/live/setlists/show_live.ex
+++ b/lib/setlistify_web/live/setlists/show_live.ex
@@ -237,22 +237,9 @@ defmodule SetlistifyWeb.Setlists.ShowLive do
                 </.button>
               </div>
             <% else %>
-              <div class="space-y-4">
-                <p class="text-gray-400 mb-4">
-                  Sign in to create a Spotify playlist from this setlist
-                </p>
-                <.link
-                  navigate={~p"/signin/spotify?redirect_to=#{@redirect_to}"}
-                  class={[
-                    "inline-flex items-center justify-center",
-                    "bg-emerald-500 text-black font-semibold",
-                    "px-6 py-3 rounded-full",
-                    "hover:bg-emerald-400 transition-colors"
-                  ]}
-                >
-                  <.icon name="hero-arrow-right-end-on-rectangle" class="mr-2" /> Sign in with Spotify
-                </.link>
-              </div>
+              <p class="text-gray-400">
+                Sign in to create a playlist from this setlist
+              </p>
             <% end %>
           </div>
         </div>


### PR DESCRIPTION
## Summary

- Removes the Spotify-specific sign-in prompt and button from the unauthenticated setlist view
- Replaces it with a simple "Sign in to create a playlist from this setlist" message, deferring to the navbar sign-in buttons for both Spotify and Apple Music

## Why

Now that Apple Music is supported, the old Spotify-only CTA was misleading. Rather than duplicating the Apple Music auth hook logic (which requires a JS hook + developer token), we direct users to the always-visible navbar sign-in buttons.

Closes #91

## Test plan

- [ ] Visit `/setlist/:id` while logged out — confirm the card shows the generic message with no Spotify button
- [ ] Confirm the navbar still shows both Spotify and Apple Music sign-in options
- [ ] Sign in with Spotify and confirm the "Create Playlist" button appears as expected
- [ ] Sign in with Apple Music and confirm the "Create Playlist" button appears as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)