### PR TITLE
feat: introduce Setlistify.Cache and fix Cachex result unwrapping

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -28,9 +28,11 @@ config :setlistify,
     retry: false
   ]
 
-# Disable OpenTelemetry exports in test
+# Disable OpenTelemetry exports in test, but keep the simple processor running
+# so tests can redirect spans to themselves via :otel_simple_processor.set_exporter/2
 config :opentelemetry,
-  traces_exporter: :none
+  traces_exporter: :none,
+  processors: [{:otel_simple_processor, %{}}]
 
 # Disable PromEx for tests
 config :setlistify, Setlistify.PromEx,

--- a/lib/setlistify/apple_music/api.ex
+++ b/lib/setlistify/apple_music/api.ex
@@ -5,8 +5,6 @@ defmodule Setlistify.AppleMusic.API do
 
   @behaviour Setlistify.MusicService.API
 
-  require OpenTelemetry.Tracer
-
   alias Setlistify.AppleMusic.UserSession
 
   @callback build_user_session(String.t(), String.t(), String.t()) ::
@@ -17,19 +15,11 @@ defmodule Setlistify.AppleMusic.API do
   end
 
   @callback search_for_track(UserSession.t(), String.t(), String.t()) ::
-              nil | %{track_id: String.t()}
+              nil | %{track_id: String.t()} | {:error, atom()}
   def search_for_track(user_session, artist, track) do
-    parent_ctx = OpenTelemetry.Ctx.get_current()
-    parent_span = OpenTelemetry.Tracer.current_span_ctx(parent_ctx)
-
-    :apple_music_track_cache
-    |> Cachex.fetch({artist, track}, fn {artist, track} ->
-      OpenTelemetry.Ctx.attach(parent_ctx)
-      OpenTelemetry.Tracer.set_current_span(parent_span)
-
+    Setlistify.Cache.fetch(:apple_music_track_cache, {artist, track}, fn {artist, track} ->
       impl().search_for_track(user_session, artist, track)
     end)
-    |> elem(1)
   end
 
   @callback create_playlist(UserSession.t(), String.t(), String.t()) ::

--- a/lib/setlistify/cache.ex
+++ b/lib/setlistify/cache.ex
@@ -32,6 +32,11 @@ defmodule Setlistify.Cache do
   - Returning `{:error, reason}` is treated by Cachex as a failed fetch — the
     value is not cached and `{:error, reason}` is returned to the caller.
 
+  Note: `{:ignore, value}` and `{:error, reason}` both skip caching, but they
+  differ in what Cachex returns: `{:ignore, value}` preserves the full value
+  (useful for structured error tuples like `{:error, reason}`), while `{:error,
+  reason}` only preserves the reason atom.
+
   Sets `cache.hit` on the current OpenTelemetry span:
   - `true` when the value was already in cache
   - `false` when the callback was invoked (miss, error, or ignored result)
@@ -52,6 +57,10 @@ defmodule Setlistify.Cache do
         result
 
       {:commit, result} ->
+        OpenTelemetry.Tracer.set_attribute("cache.hit", false)
+        result
+
+      {:ignore, result} ->
         OpenTelemetry.Tracer.set_attribute("cache.hit", false)
         result
 

--- a/lib/setlistify/cache.ex
+++ b/lib/setlistify/cache.ex
@@ -17,29 +17,42 @@ defmodule Setlistify.Cache do
   require OpenTelemetry.Tracer
 
   @doc """
-  Fetches a value from the cache, calling `fetch_fn` on a miss.
+  Fetches a value from `cache` by `key`, calling `fetch_fn` on a miss.
 
-  The callback receives the key and its return value determines caching behaviour.
-  We mirror Cachex's semantics and intend to maintain this contract even if the
+  The return value of `fetch_fn` determines caching behaviour. We mirror
+  Cachex's semantics and intend to maintain this contract even if the
   underlying library changes:
 
-  - Returning a plain value (e.g. `%{track_id: id}` or `nil`) commits it to
-    cache and returns it.
-  - Returning `{:commit, value}` explicitly commits `value` to cache and returns
-    it. Useful when the callback needs to signal intent clearly.
-  - Returning `{:ignore, value}` returns `value` without storing it in cache.
-    Use this for transient errors or other results that should not be cached.
-  - Returning `{:error, reason}` is treated by Cachex as a failed fetch — the
-    value is not cached and `{:error, reason}` is returned to the caller.
+    * Plain value (e.g. `%{track_id: id}` or `nil`) — committed to cache
+      and returned.
+    * `{:commit, value}` — `value` committed to cache and returned.
+    * `{:ignore, value}` — `value` returned without caching.
+    * `{:error, reason}` — treated as a failed fetch; not cached, and
+      `{:error, reason}` is returned to the caller.
 
-  Note: `{:ignore, value}` and `{:error, reason}` both skip caching, but they
-  differ in what Cachex returns: `{:ignore, value}` preserves the full value
-  (useful for structured error tuples like `{:error, reason}`), while `{:error,
-  reason}` only preserves the reason atom.
+  `{:ignore, value}` and `{:error, reason}` are equivalent when `value` is
+  an error tuple — both skip caching and return `{:error, reason}`. Prefer
+  `{:ignore, {:error, reason}}` to make the intent explicit.
 
-  Sets `cache.hit` on the current OpenTelemetry span:
-  - `true` when the value was already in cache
-  - `false` when the callback was invoked (miss, error, or ignored result)
+  ## OpenTelemetry
+
+  Sets `cache.hit` on the current span:
+
+    * `true` — value was served from cache
+    * `false` — callback was invoked (miss, ignored, or error)
+
+  ## Examples
+
+      iex> {:ok, _} = Cachex.start_link(name: :cachex_doctest_fetch)
+      iex> Setlistify.Cache.fetch(:cachex_doctest_fetch, "hit", fn _ -> %{track_id: "abc"} end)
+      %{track_id: "abc"}
+      iex> Cachex.exists?(:cachex_doctest_fetch, "hit")
+      {:ok, true}
+      iex> Setlistify.Cache.fetch(:cachex_doctest_fetch, "miss", fn _ -> {:ignore, {:error, :transient}} end)
+      {:error, :transient}
+      iex> Cachex.exists?(:cachex_doctest_fetch, "miss")
+      {:ok, false}
+
   """
   def fetch(cache, key, fetch_fn) do
     parent_ctx = OpenTelemetry.Ctx.get_current()

--- a/lib/setlistify/cache.ex
+++ b/lib/setlistify/cache.ex
@@ -8,10 +8,11 @@ defmodule Setlistify.Cache do
   and callers stay the same.
 
   In addition to delegating to Cachex, this module:
-  - Propagates OpenTelemetry context into Cachex's worker process, so traces
-    aren't broken across the process boundary
-  - Sets a `cache.hit` span attribute on the current span, enabling cache hit
-    rate tracking in traces
+
+    * Propagates OpenTelemetry context into Cachex's worker process, so traces
+      aren't broken across the process boundary
+    * Sets a `cache.hit` span attribute on the current span, enabling cache hit
+      rate tracking in traces
   """
 
   require OpenTelemetry.Tracer

--- a/lib/setlistify/cache.ex
+++ b/lib/setlistify/cache.ex
@@ -1,0 +1,63 @@
+defmodule Setlistify.Cache do
+  @moduledoc """
+  Wrapper around Cachex for application caching.
+
+  All caching in the application should go through this module rather than
+  calling Cachex directly. This keeps the Cachex dependency contained to one
+  place — if we swap the underlying library, only this module needs to change,
+  and callers stay the same.
+
+  In addition to delegating to Cachex, this module:
+  - Propagates OpenTelemetry context into Cachex's worker process, so traces
+    aren't broken across the process boundary
+  - Sets a `cache.hit` span attribute on the current span, enabling cache hit
+    rate tracking in traces
+  """
+
+  require OpenTelemetry.Tracer
+
+  @doc """
+  Fetches a value from the cache, calling `fetch_fn` on a miss.
+
+  The callback receives the key and its return value determines caching behaviour.
+  We mirror Cachex's semantics and intend to maintain this contract even if the
+  underlying library changes:
+
+  - Returning a plain value (e.g. `%{track_id: id}` or `nil`) commits it to
+    cache and returns it.
+  - Returning `{:commit, value}` explicitly commits `value` to cache and returns
+    it. Useful when the callback needs to signal intent clearly.
+  - Returning `{:ignore, value}` returns `value` without storing it in cache.
+    Use this for transient errors or other results that should not be cached.
+  - Returning `{:error, reason}` is treated by Cachex as a failed fetch — the
+    value is not cached and `{:error, reason}` is returned to the caller.
+
+  Sets `cache.hit` on the current OpenTelemetry span:
+  - `true` when the value was already in cache
+  - `false` when the callback was invoked (miss, error, or ignored result)
+  """
+  def fetch(cache, key, fetch_fn) do
+    parent_ctx = OpenTelemetry.Ctx.get_current()
+    parent_span = OpenTelemetry.Tracer.current_span_ctx(parent_ctx)
+
+    cache
+    |> Cachex.fetch(key, fn key ->
+      OpenTelemetry.Ctx.attach(parent_ctx)
+      OpenTelemetry.Tracer.set_current_span(parent_span)
+      fetch_fn.(key)
+    end)
+    |> case do
+      {:ok, result} ->
+        OpenTelemetry.Tracer.set_attribute("cache.hit", true)
+        result
+
+      {:commit, result} ->
+        OpenTelemetry.Tracer.set_attribute("cache.hit", false)
+        result
+
+      {:error, _} = error ->
+        OpenTelemetry.Tracer.set_attribute("cache.hit", false)
+        error
+    end
+  end
+end

--- a/lib/setlistify/setlist_fm/api.ex
+++ b/lib/setlistify/setlist_fm/api.ex
@@ -67,7 +67,7 @@ defmodule Setlistify.SetlistFm.API do
         case impl().search(query, page) do
           {:ok, _} = success -> {:commit, success}
           {:error, :not_found} = error -> {:commit, error}
-          {:error, _} = error -> {:ignore, error}
+          {:error, _} = error -> error
         end
       end)
     end
@@ -83,15 +83,8 @@ defmodule Setlistify.SetlistFm.API do
       ])
 
       Setlistify.Cache.fetch(:setlist_fm_setlist_cache, id, fn _ ->
-        case impl().get_setlist(id) do
-          {:ok, setlist} -> {:commit, setlist}
-          {:error, reason} -> {:ignore, {:error, reason}}
-        end
+        impl().get_setlist(id)
       end)
-      |> case do
-        {:error, _} = error -> error
-        setlist -> {:ok, setlist}
-      end
     end
   end
 

--- a/lib/setlistify/setlist_fm/api.ex
+++ b/lib/setlistify/setlist_fm/api.ex
@@ -61,32 +61,15 @@ defmodule Setlistify.SetlistFm.API do
         {"setlist_fm.search.page", page}
       ])
 
-      # Cachex uses a separate process, so we need to propagate OpenTelemetry context
-      parent_ctx = OpenTelemetry.Ctx.get_current()
-      parent_span = OpenTelemetry.Tracer.current_span_ctx(parent_ctx)
-
       # Warning: different pages may have different expiration times in cache,
       # which could cause consistency issues if this becomes problematic
-      cache_key = {query, page}
-
-      result =
-        :setlist_fm_search_cache
-        |> Cachex.fetch(cache_key, fn _cache_key ->
-          OpenTelemetry.Ctx.attach(parent_ctx)
-          OpenTelemetry.Tracer.set_current_span(parent_span)
-
-          case impl().search(query, page) do
-            {:ok, _} = success -> {:commit, success}
-            {:error, :not_found} = error -> {:commit, error}
-            {:error, _} = error -> {:ignore, error}
-          end
-        end)
-
-      case result do
-        {:ok, response} -> response
-        {:commit, response} -> response
-        {:ignore, result} -> result
-      end
+      Setlistify.Cache.fetch(:setlist_fm_search_cache, {query, page}, fn _cache_key ->
+        case impl().search(query, page) do
+          {:ok, _} = success -> {:commit, success}
+          {:error, :not_found} = error -> {:commit, error}
+          {:error, _} = error -> {:ignore, error}
+        end
+      end)
     end
   end
 
@@ -99,27 +82,12 @@ defmodule Setlistify.SetlistFm.API do
         {"setlist_fm.setlist.id", id}
       ])
 
-      # Cachex uses a separate process, so we need to propagate OpenTelemetry context
-      parent_ctx = OpenTelemetry.Ctx.get_current()
-      parent_span = OpenTelemetry.Tracer.current_span_ctx(parent_ctx)
-
-      result =
-        :setlist_fm_setlist_cache
-        |> Cachex.fetch(id, fn id ->
-          OpenTelemetry.Ctx.attach(parent_ctx)
-          OpenTelemetry.Tracer.set_current_span(parent_span)
-
-          case impl().get_setlist(id) do
-            {:ok, setlist} -> {:commit, setlist}
-            {:error, reason} -> {:ignore, {:error, reason}}
-          end
-        end)
-
-      case result do
-        {:ok, setlist} -> {:ok, setlist}
-        {:commit, setlist} -> {:ok, setlist}
-        {:ignore, {:error, reason}} -> {:error, reason}
-      end
+      Setlistify.Cache.fetch(:setlist_fm_setlist_cache, id, fn id ->
+        case impl().get_setlist(id) do
+          {:ok, _} = result -> {:commit, result}
+          {:error, reason} -> {:ignore, {:error, reason}}
+        end
+      end)
     end
   end
 

--- a/lib/setlistify/setlist_fm/api.ex
+++ b/lib/setlistify/setlist_fm/api.ex
@@ -63,7 +63,7 @@ defmodule Setlistify.SetlistFm.API do
 
       # Warning: different pages may have different expiration times in cache,
       # which could cause consistency issues if this becomes problematic
-      Setlistify.Cache.fetch(:setlist_fm_search_cache, {query, page}, fn _cache_key ->
+      Setlistify.Cache.fetch(:setlist_fm_search_cache, {query, page}, fn _ ->
         case impl().search(query, page) do
           {:ok, _} = success -> {:commit, success}
           {:error, :not_found} = error -> {:commit, error}
@@ -82,12 +82,16 @@ defmodule Setlistify.SetlistFm.API do
         {"setlist_fm.setlist.id", id}
       ])
 
-      Setlistify.Cache.fetch(:setlist_fm_setlist_cache, id, fn id ->
+      Setlistify.Cache.fetch(:setlist_fm_setlist_cache, id, fn _ ->
         case impl().get_setlist(id) do
-          {:ok, _} = result -> {:commit, result}
+          {:ok, setlist} -> {:commit, setlist}
           {:error, reason} -> {:ignore, {:error, reason}}
         end
       end)
+      |> case do
+        {:error, _} = error -> error
+        setlist -> {:ok, setlist}
+      end
     end
   end
 

--- a/lib/setlistify/spotify/api.ex
+++ b/lib/setlistify/spotify/api.ex
@@ -5,23 +5,12 @@ defmodule Setlistify.Spotify.API do
 
   alias Setlistify.Spotify.UserSession
 
-  # TODO Set response type
   @callback search_for_track(UserSession.t(), String.t(), String.t()) ::
-              nil | %{track_id: String.t()}
+              nil | %{track_id: String.t()} | {:error, atom()}
   def search_for_track(user_session, artist, track) do
-    # Cachex uses a separate process, so we need to propogate OpenTelemetry context
-    # TODO: If we do this enough we should consider making a helper
-    parent_ctx = OpenTelemetry.Ctx.get_current()
-    parent_span = OpenTelemetry.Tracer.current_span_ctx(parent_ctx)
-
-    :spotify_track_cache
-    |> Cachex.fetch({artist, track}, fn {artist, track} ->
-      OpenTelemetry.Ctx.attach(parent_ctx)
-      OpenTelemetry.Tracer.set_current_span(parent_span)
-
+    Setlistify.Cache.fetch(:spotify_track_cache, {artist, track}, fn {artist, track} ->
       impl().search_for_track(user_session, artist, track)
     end)
-    |> elem(1)
   end
 
   @callback create_playlist(UserSession.t(), String.t(), String.t()) ::

--- a/test/setlistify/apple_music/api_test.exs
+++ b/test/setlistify/apple_music/api_test.exs
@@ -1,8 +1,24 @@
 defmodule Setlistify.AppleMusic.APITest do
-  use Setlistify.DataCase, async: true
+  use Setlistify.DataCase, async: false
+
+  import Hammox
 
   alias Setlistify.AppleMusic.API
   alias Setlistify.AppleMusic.UserSession
+
+  # Cachex runs in a separate process, so we need global mox mode
+  setup :set_mox_from_context
+  setup :verify_on_exit!
+
+  setup do
+    on_exit(:clear_cache, fn ->
+      Cachex.clear!(:apple_music_track_cache)
+    end)
+
+    user_session = %UserSession{user_token: "token", storefront: "us", user_id: "user-123"}
+
+    {:ok, user_session: user_session}
+  end
 
   describe "build_user_session/3" do
     test "returns a UserSession struct with the given fields" do
@@ -12,6 +28,37 @@ defmodule Setlistify.AppleMusic.APITest do
       assert session.user_token == "user_token"
       assert session.storefront == "us"
       assert session.user_id == "user-id-123"
+    end
+  end
+
+  describe "search_for_track/3" do
+    test "returns the full error tuple when impl returns an error", %{
+      user_session: user_session
+    } do
+      expect(Setlistify.AppleMusic.API.MockClient, :search_for_track, 1, fn _session,
+                                                                            _artist,
+                                                                            _track ->
+        {:error, :token_refresh_failed}
+      end)
+
+      # Without the fix, elem(1) on Cachex's {:error, :token_refresh_failed} return
+      # yields just :token_refresh_failed (the atom), not the full error tuple
+      assert {:error, :token_refresh_failed} =
+               API.search_for_track(user_session, "Artist", "Track")
+    end
+
+    test "caches successful results — impl is called only once", %{user_session: user_session} do
+      expect(Setlistify.AppleMusic.API.MockClient, :search_for_track, 1, fn _session,
+                                                                            _artist,
+                                                                            _track ->
+        %{track_id: "am:track:abc123"}
+      end)
+
+      assert %{track_id: "am:track:abc123"} =
+               API.search_for_track(user_session, "Artist", "Track")
+
+      assert %{track_id: "am:track:abc123"} =
+               API.search_for_track(user_session, "Artist", "Track")
     end
   end
 end

--- a/test/setlistify/apple_music/api_test.exs
+++ b/test/setlistify/apple_music/api_test.exs
@@ -45,8 +45,6 @@ defmodule Setlistify.AppleMusic.APITest do
         {:error, :token_refresh_failed}
       end)
 
-      # Without the fix, elem(1) on Cachex's {:error, :token_refresh_failed} return
-      # yields just :token_refresh_failed (the atom), not the full error tuple
       assert {:error, :token_refresh_failed} =
                API.search_for_track(user_session, "Artist", "Track")
     end

--- a/test/setlistify/apple_music/api_test.exs
+++ b/test/setlistify/apple_music/api_test.exs
@@ -6,7 +6,11 @@ defmodule Setlistify.AppleMusic.APITest do
   alias Setlistify.AppleMusic.API
   alias Setlistify.AppleMusic.UserSession
 
-  # Cachex runs in a separate process, so we need global mox mode
+  # Cache fetching happens in another process, managed by Cachex. The process we
+  # start in our application tree is a supervisor, so explicitly `allow`ing with
+  # that PID does not work. This will enable "global" mode which means any
+  # process will respect our `expect` at the cost of not being able to run with
+  # `async: true`
   setup :set_mox_from_context
   setup :verify_on_exit!
 

--- a/test/setlistify/cache_test.exs
+++ b/test/setlistify/cache_test.exs
@@ -76,12 +76,12 @@ defmodule Setlistify.CacheTest do
       :ok
     end
 
-    test "sets cache.hit=false on cache miss", %{cache: cache} do
+    test "sets cache.hit=false on first fetch (commit)", %{cache: cache} do
       OpenTelemetry.Tracer.with_span "test" do
         Cache.fetch(cache, "key", fn _ -> "value" end)
       end
 
-      assert_receive {:span, s}
+      assert_receive {:span, span(name: "test") = s}
       assert %{"cache.hit" => false} = span_attributes(s)
     end
 
@@ -92,7 +92,7 @@ defmodule Setlistify.CacheTest do
         Cache.fetch(cache, "key", fn _ -> "other_value" end)
       end
 
-      assert_receive {:span, s}
+      assert_receive {:span, span(name: "test") = s}
       assert %{"cache.hit" => true} = span_attributes(s)
     end
 
@@ -101,7 +101,7 @@ defmodule Setlistify.CacheTest do
         Cache.fetch(cache, "key", fn _ -> {:error, :some_error} end)
       end
 
-      assert_receive {:span, s}
+      assert_receive {:span, span(name: "test") = s}
       assert %{"cache.hit" => false} = span_attributes(s)
     end
 
@@ -110,7 +110,7 @@ defmodule Setlistify.CacheTest do
         Cache.fetch(cache, "key", fn _ -> {:ignore, "not_cached"} end)
       end
 
-      assert_receive {:span, s}
+      assert_receive {:span, span(name: "test") = s}
       assert %{"cache.hit" => false} = span_attributes(s)
     end
   end

--- a/test/setlistify/cache_test.exs
+++ b/test/setlistify/cache_test.exs
@@ -1,4 +1,9 @@
 defmodule Setlistify.CacheTest do
+  # async: false for two reasons:
+  # 1. :otel_simple_processor.set_exporter/2 is a global side effect — concurrent
+  #    tests would overwrite each other's exporter and receive wrong spans
+  # 2. start_supervised! starts a named process (:cache_test) — concurrent tests
+  #    would race to register the same name and crash
   use Setlistify.DataCase, async: false
 
   require OpenTelemetry.Tracer
@@ -8,6 +13,10 @@ defmodule Setlistify.CacheTest do
 
   doctest Setlistify.Cache
 
+  # Record.defrecord extracts the :span record field names from the Erlang include
+  # at compile time, giving us named access (span(s, :attributes)) rather than
+  # positional access (elem(s, 9)), which would silently break if OTel ever
+  # reorders the record fields.
   Record.defrecord(
     :span,
     :span,
@@ -21,6 +30,7 @@ defmodule Setlistify.CacheTest do
 
   describe "fetch/3 caching behavior" do
     test "stores successful result in cache on miss", %{cache: cache} do
+      assert {:ok, false} = Cachex.exists?(cache, "key")
       Cache.fetch(cache, "key", fn _ -> "value" end)
       assert {:ok, "value"} = Cachex.get(cache, "key")
     end

--- a/test/setlistify/cache_test.exs
+++ b/test/setlistify/cache_test.exs
@@ -6,6 +6,8 @@ defmodule Setlistify.CacheTest do
 
   alias Setlistify.Cache
 
+  doctest Setlistify.Cache
+
   Record.defrecord(
     :span,
     :span,

--- a/test/setlistify/cache_test.exs
+++ b/test/setlistify/cache_test.exs
@@ -1,0 +1,101 @@
+defmodule Setlistify.CacheTest do
+  use Setlistify.DataCase, async: false
+
+  require OpenTelemetry.Tracer
+  require Record
+
+  alias Setlistify.Cache
+
+  Record.defrecord(
+    :span,
+    :span,
+    Record.extract(:span, from_lib: "opentelemetry/include/otel_span.hrl")
+  )
+
+  setup do
+    start_supervised!({Cachex, name: :cache_test})
+    {:ok, cache: :cache_test}
+  end
+
+  describe "fetch/3 caching behavior" do
+    test "stores successful result in cache on miss", %{cache: cache} do
+      Cache.fetch(cache, "key", fn _ -> "value" end)
+      assert {:ok, "value"} = Cachex.get(cache, "key")
+    end
+
+    test "returns result on cache miss", %{cache: cache} do
+      assert "value" == Cache.fetch(cache, "key", fn _ -> "value" end)
+    end
+
+    test "returns cached result on cache hit", %{cache: cache} do
+      Cachex.put(cache, "key", "cached_value")
+      assert "cached_value" == Cache.fetch(cache, "key", fn _ -> "other_value" end)
+    end
+
+    test "calls fn only once for repeated fetches of the same key", %{cache: cache} do
+      parent = self()
+
+      Cache.fetch(cache, "key", fn _ ->
+        send(parent, :fn_called)
+        "value"
+      end)
+
+      Cache.fetch(cache, "key", fn _ ->
+        send(parent, :fn_called)
+        "value"
+      end)
+
+      assert_received :fn_called
+      refute_received :fn_called
+    end
+
+    test "does not store error results in cache", %{cache: cache} do
+      Cache.fetch(cache, "key", fn _ -> {:error, :some_error} end)
+      assert {:ok, false} = Cachex.exists?(cache, "key")
+    end
+
+    test "returns full error tuple on error", %{cache: cache} do
+      assert {:error, :some_error} = Cache.fetch(cache, "key", fn _ -> {:error, :some_error} end)
+    end
+  end
+
+  describe "fetch/3 OpenTelemetry" do
+    setup do
+      :otel_simple_processor.set_exporter(:otel_exporter_pid, self())
+      :ok
+    end
+
+    test "sets cache.hit=false on cache miss", %{cache: cache} do
+      OpenTelemetry.Tracer.with_span "test" do
+        Cache.fetch(cache, "key", fn _ -> "value" end)
+      end
+
+      assert_receive {:span, s}
+      assert %{"cache.hit" => false} = span_attributes(s)
+    end
+
+    test "sets cache.hit=true on cache hit", %{cache: cache} do
+      Cachex.put(cache, "key", "cached_value")
+
+      OpenTelemetry.Tracer.with_span "test" do
+        Cache.fetch(cache, "key", fn _ -> "other_value" end)
+      end
+
+      assert_receive {:span, s}
+      assert %{"cache.hit" => true} = span_attributes(s)
+    end
+
+    test "sets cache.hit=false on error", %{cache: cache} do
+      OpenTelemetry.Tracer.with_span "test" do
+        Cache.fetch(cache, "key", fn _ -> {:error, :some_error} end)
+      end
+
+      assert_receive {:span, s}
+      assert %{"cache.hit" => false} = span_attributes(s)
+    end
+  end
+
+  defp span_attributes(span_record) do
+    span_record |> span(:attributes) |> :otel_attributes.map()
+  end
+end

--- a/test/setlistify/cache_test.exs
+++ b/test/setlistify/cache_test.exs
@@ -57,6 +57,15 @@ defmodule Setlistify.CacheTest do
     test "returns full error tuple on error", %{cache: cache} do
       assert {:error, :some_error} = Cache.fetch(cache, "key", fn _ -> {:error, :some_error} end)
     end
+
+    test "does not store {:ignore, value} results in cache", %{cache: cache} do
+      Cache.fetch(cache, "key", fn _ -> {:ignore, "not_cached"} end)
+      assert {:ok, false} = Cachex.exists?(cache, "key")
+    end
+
+    test "returns the value from {:ignore, value}", %{cache: cache} do
+      assert "not_cached" == Cache.fetch(cache, "key", fn _ -> {:ignore, "not_cached"} end)
+    end
   end
 
   describe "fetch/3 OpenTelemetry" do
@@ -88,6 +97,15 @@ defmodule Setlistify.CacheTest do
     test "sets cache.hit=false on error", %{cache: cache} do
       OpenTelemetry.Tracer.with_span "test" do
         Cache.fetch(cache, "key", fn _ -> {:error, :some_error} end)
+      end
+
+      assert_receive {:span, s}
+      assert %{"cache.hit" => false} = span_attributes(s)
+    end
+
+    test "sets cache.hit=false on {:ignore, value}", %{cache: cache} do
+      OpenTelemetry.Tracer.with_span "test" do
+        Cache.fetch(cache, "key", fn _ -> {:ignore, "not_cached"} end)
       end
 
       assert_receive {:span, s}

--- a/test/setlistify/setlist_fm/api_test.exs
+++ b/test/setlistify/setlist_fm/api_test.exs
@@ -1,0 +1,90 @@
+defmodule Setlistify.SetlistFm.APITest do
+  use Setlistify.DataCase, async: false
+
+  import Hammox
+
+  alias Setlistify.SetlistFm.API
+
+  setup :set_mox_from_context
+  setup :verify_on_exit!
+
+  setup do
+    on_exit(fn ->
+      Cachex.clear!(:setlist_fm_search_cache)
+      Cachex.clear!(:setlist_fm_setlist_cache)
+    end)
+  end
+
+  describe "search/2 caching" do
+    test "caches successful results — impl called only once for the same query" do
+      expect(Setlistify.SetlistFm.API.MockClient, :search, 1, fn _query, _page ->
+        {:ok, %{setlists: [], pagination: %{page: 1, total: 0, items_per_page: 20}}}
+      end)
+
+      assert {:ok, _} = API.search("artist")
+      assert {:ok, _} = API.search("artist")
+    end
+
+    test "caches :not_found — impl called only once for the same query" do
+      expect(Setlistify.SetlistFm.API.MockClient, :search, 1, fn _query, _page ->
+        {:error, :not_found}
+      end)
+
+      assert {:error, :not_found} = API.search("unknown artist")
+      assert {:error, :not_found} = API.search("unknown artist")
+    end
+
+    test "does not cache transient errors — impl called again on retry" do
+      expect(Setlistify.SetlistFm.API.MockClient, :search, 1, fn _query, _page ->
+        {:error, {:api_error, 500}}
+      end)
+
+      assert {:error, {:api_error, 500}} = API.search("artist")
+
+      expect(Setlistify.SetlistFm.API.MockClient, :search, 1, fn _query, _page ->
+        {:ok, %{setlists: [], pagination: %{page: 1, total: 0, items_per_page: 20}}}
+      end)
+
+      assert {:ok, _} = API.search("artist")
+    end
+  end
+
+  describe "get_setlist/1 caching" do
+    test "caches successful results — impl called only once for the same id" do
+      setlist = %{
+        artist: "The Beatles",
+        venue: %{name: "Venue", location: %{city: "NYC", state: nil, country: "US"}},
+        date: ~D[2024-01-01],
+        sets: []
+      }
+
+      expect(Setlistify.SetlistFm.API.MockClient, :get_setlist, 1, fn _id ->
+        {:ok, setlist}
+      end)
+
+      assert {:ok, ^setlist} = API.get_setlist("setlist-id")
+      assert {:ok, ^setlist} = API.get_setlist("setlist-id")
+    end
+
+    test "does not cache errors — impl called again on retry" do
+      expect(Setlistify.SetlistFm.API.MockClient, :get_setlist, 1, fn _id ->
+        {:error, :not_found}
+      end)
+
+      assert {:error, :not_found} = API.get_setlist("bad-id")
+
+      setlist = %{
+        artist: "The Beatles",
+        venue: %{name: "Venue", location: %{city: "NYC", state: nil, country: "US"}},
+        date: ~D[2024-01-01],
+        sets: []
+      }
+
+      expect(Setlistify.SetlistFm.API.MockClient, :get_setlist, 1, fn _id ->
+        {:ok, setlist}
+      end)
+
+      assert {:ok, ^setlist} = API.get_setlist("bad-id")
+    end
+  end
+end

--- a/test/setlistify/spotify/api_test.exs
+++ b/test/setlistify/spotify/api_test.exs
@@ -36,8 +36,6 @@ defmodule Setlistify.Spotify.APITest do
         {:error, :token_refresh_failed}
       end)
 
-      # Without the fix, elem(1) on Cachex's {:error, :token_refresh_failed} return
-      # yields just :token_refresh_failed (the atom), not the full error tuple
       assert {:error, :token_refresh_failed} =
                API.search_for_track(user_session, "Artist", "Track")
     end

--- a/test/setlistify/spotify/api_test.exs
+++ b/test/setlistify/spotify/api_test.exs
@@ -1,0 +1,59 @@
+defmodule Setlistify.Spotify.APITest do
+  use Setlistify.DataCase, async: false
+
+  import Hammox
+
+  alias Setlistify.Spotify.API
+  alias Setlistify.Spotify.UserSession
+
+  # Cachex runs in a separate process, so we need global mox mode
+  setup :set_mox_from_context
+  setup :verify_on_exit!
+
+  setup do
+    on_exit(:clear_cache, fn ->
+      Cachex.clear!(:spotify_track_cache)
+    end)
+
+    user_session = %UserSession{
+      access_token: "token",
+      refresh_token: "refresh_token",
+      expires_at: System.system_time(:second) + 3600,
+      user_id: "user-123",
+      username: "Test User"
+    }
+
+    {:ok, user_session: user_session}
+  end
+
+  describe "search_for_track/3" do
+    test "returns the full error tuple when impl returns an error", %{
+      user_session: user_session
+    } do
+      expect(Setlistify.Spotify.API.MockClient, :search_for_track, 1, fn _session,
+                                                                         _artist,
+                                                                         _track ->
+        {:error, :token_refresh_failed}
+      end)
+
+      # Without the fix, elem(1) on Cachex's {:error, :token_refresh_failed} return
+      # yields just :token_refresh_failed (the atom), not the full error tuple
+      assert {:error, :token_refresh_failed} =
+               API.search_for_track(user_session, "Artist", "Track")
+    end
+
+    test "caches successful results — impl is called only once", %{user_session: user_session} do
+      expect(Setlistify.Spotify.API.MockClient, :search_for_track, 1, fn _session,
+                                                                         _artist,
+                                                                         _track ->
+        %{track_id: "spotify:track:abc123"}
+      end)
+
+      assert %{track_id: "spotify:track:abc123"} =
+               API.search_for_track(user_session, "Artist", "Track")
+
+      assert %{track_id: "spotify:track:abc123"} =
+               API.search_for_track(user_session, "Artist", "Track")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Fixes a bug where `search_for_track` in `Spotify.API` and `AppleMusic.API` returned a bare reason atom (e.g. `:token_refresh_failed`) instead of the full `{:error, reason}` tuple when the impl returned an error — caused by `elem(1)` on Cachex's `{:error, _}` return shape
- Introduces `Setlistify.Cache` as the single wrapper around Cachex, so all caching goes through one module; swapping the underlying library only requires changes here
- Adds OTel context propagation and `cache.hit` span attribute tracking to every cache fetch
- Migrates `Spotify.API`, `AppleMusic.API`, and `SetlistFm.API` off direct Cachex calls
- Updates `@callback` specs for `search_for_track` to include `{:error, atom()}` which the `ExternalClient` could already return
- Enables the OTel simple processor in test config so `cache.hit` attributes can be asserted in tests

## Test plan

- [ ] `mix test` passes (229 tests + 1 doctest, 0 failures)
- [ ] New `Setlistify.CacheTest` covers: cache miss stores value, cache hit skips fn, error not stored, `{:ignore, _}` not stored, `cache.hit` OTel attribute for each path
- [ ] New `Setlistify.Spotify.APITest` and updated `Setlistify.AppleMusic.APITest` prove the error tuple is returned correctly and successful results are cached
- [ ] New `Setlistify.SetlistFm.APITest` covers: success cached, `:not_found` cached, transient errors not cached, `get_setlist` errors not cached

🤖 Generated with [Claude Code](https://claude.com/claude-code)