### PR TITLE
fix: use dynamic provider in OTel music.service span attribute

### DIFF
--- a/lib/setlistify_web/live/setlists/show_live.ex
+++ b/lib/setlistify_web/live/setlists/show_live.ex
@@ -45,8 +45,8 @@ defmodule SetlistifyWeb.Setlists.ShowLive do
                   OpenTelemetry.Tracer.with_span "SetlistifyWeb.Setlists.ShowLive.search_song_async" do
                     OpenTelemetry.Tracer.set_attributes([
                       {"music.service", provider(user_session)},
-                      {"song.title", song.title},
-                      {"song.artist", setlist.artist},
+                      {"music.track", song.title},
+                      {"music.artist", setlist.artist},
                       {"song.set_index", set_index},
                       {"song.song_index", song_index}
                     ])

--- a/lib/setlistify_web/live/setlists/show_live.ex
+++ b/lib/setlistify_web/live/setlists/show_live.ex
@@ -44,7 +44,7 @@ defmodule SetlistifyWeb.Setlists.ShowLive do
                 fn ->
                   OpenTelemetry.Tracer.with_span "SetlistifyWeb.Setlists.ShowLive.search_song_async" do
                     OpenTelemetry.Tracer.set_attributes([
-                      {"music.service", "spotify"},
+                      {"music.service", provider(user_session)},
                       {"song.title", song.title},
                       {"song.artist", setlist.artist},
                       {"song.set_index", set_index},


### PR DESCRIPTION
## Summary
- Replace hardcoded `"spotify"` with `provider(user_session)` in the async song-search OTel span so Apple Music sessions are correctly attributed
- Rename `song.title` → `music.track` and `song.artist` → `music.artist` to match the ADR-003 generic attribute naming convention used in both provider ExternalClients

Closes #97

## Test plan
- [x] All 229 tests pass
- [x] `mix format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)