### PR TITLE
test: add missing Spotify test coverage for SessionManager and RestoreSpotifyToken

### DIFF
--- a/test/setlistify/spotify/session_manager_test.exs
+++ b/test/setlistify/spotify/session_manager_test.exs
@@ -128,6 +128,51 @@ defmodule Setlistify.Spotify.SessionManagerTest do
     end
   end
 
+  describe "stop/1" do
+    test "terminates the process", %{user_id: user_id, initial_token: initial_token} do
+      user_session = %UserSession{
+        access_token: initial_token.access_token,
+        refresh_token: initial_token.refresh_token,
+        expires_at: System.system_time(:second) + initial_token.expires_in,
+        user_id: user_id,
+        username: "test_user"
+      }
+
+      {:ok, pid} = SessionManager.start_link({user_id, user_session})
+      assert Process.alive?(pid)
+      assert :ok = SessionManager.stop(user_id)
+      refute Process.alive?(pid)
+    end
+
+    test "returns :not_found when no process exists", %{user_id: _user_id} do
+      nonexistent_user = unique_user_id()
+      assert {:error, :not_found} = SessionManager.stop(nonexistent_user)
+    end
+  end
+
+  describe "lookup/1" do
+    test "returns {:ok, pid} when process is registered", %{
+      user_id: user_id,
+      initial_token: initial_token
+    } do
+      user_session = %UserSession{
+        access_token: initial_token.access_token,
+        refresh_token: initial_token.refresh_token,
+        expires_at: System.system_time(:second) + initial_token.expires_in,
+        user_id: user_id,
+        username: "test_user"
+      }
+
+      {:ok, pid} = SessionManager.start_link({user_id, user_session})
+      assert {:ok, ^pid} = SessionManager.lookup(user_id)
+    end
+
+    test "returns :error when no process is registered", %{user_id: _user_id} do
+      nonexistent_user = unique_user_id()
+      assert :error = SessionManager.lookup(nonexistent_user)
+    end
+  end
+
   describe "refresh_session/1" do
     test "refreshes token and returns UserSession", %{
       user_id: user_id,

--- a/test/setlistify_web/plugs/restore_spotify_token_test.exs
+++ b/test/setlistify_web/plugs/restore_spotify_token_test.exs
@@ -19,6 +19,19 @@ defmodule SetlistifyWeb.Plugs.RestoreSpotifyTokenTest do
   end
 
   describe "call/2" do
+    test "does nothing when auth_provider is apple_music", %{conn: conn, user_id: user_id} do
+      conn =
+        conn
+        |> init_test_session(%{})
+        |> fetch_flash()
+        |> put_session(:auth_provider, "apple_music")
+        |> put_session(:user_id, user_id)
+        |> RestoreSpotifyToken.call([])
+
+      refute conn.halted
+      assert get_session(conn, :user_id) == user_id
+    end
+
     test "does nothing when no user_id in session", %{conn: conn} do
       conn =
         conn


### PR DESCRIPTION
## Summary
- Add explicit `stop/1` and `lookup/1` describe blocks to the Spotify `SessionManagerTest`, matching the test structure already present in Apple Music's `SessionManagerTest`
- Add a test to `RestoreSpotifyTokenTest` verifying the plug does nothing when `auth_provider` is `"apple_music"`, matching the equivalent edge-case test in `RestoreAppleMusicTokenTest`

## Test plan
- [x] All new tests pass (`mix test` -- 234 tests, 0 failures)
- [x] `mix format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)