### PR TITLE
test: add wrapper-level tests for create_playlist and add_tracks_to_playlist

### DIFF
--- a/test/setlistify/apple_music/api_test.exs
+++ b/test/setlistify/apple_music/api_test.exs
@@ -35,6 +35,59 @@ defmodule Setlistify.AppleMusic.APITest do
     end
   end
 
+  describe "create_playlist/3" do
+    test "delegates to the impl and returns the result", %{user_session: user_session} do
+      expect(Setlistify.AppleMusic.API.MockClient, :create_playlist, 1, fn _session,
+                                                                           _name,
+                                                                           _description ->
+        {:ok, %{id: "p.playlist-1", external_url: "https://music.apple.com/playlist/1"}}
+      end)
+
+      assert {:ok, %{id: "p.playlist-1", external_url: "https://music.apple.com/playlist/1"}} =
+               API.create_playlist(user_session, "My Setlist", "Songs from a concert")
+    end
+
+    test "returns the error when impl returns an error", %{user_session: user_session} do
+      expect(Setlistify.AppleMusic.API.MockClient, :create_playlist, 1, fn _session,
+                                                                           _name,
+                                                                           _description ->
+        {:error, :unauthorized}
+      end)
+
+      assert {:error, :unauthorized} =
+               API.create_playlist(user_session, "My Setlist", "Songs from a concert")
+    end
+  end
+
+  describe "add_tracks_to_playlist/3" do
+    test "delegates to the impl and returns the result", %{user_session: user_session} do
+      expect(Setlistify.AppleMusic.API.MockClient, :add_tracks_to_playlist, 1, fn _session,
+                                                                                  _playlist_id,
+                                                                                  _tracks ->
+        {:ok, :tracks_added}
+      end)
+
+      assert {:ok, :tracks_added} =
+               API.add_tracks_to_playlist(user_session, "p.playlist-1", [
+                 "am:track:abc",
+                 "am:track:def"
+               ])
+    end
+
+    test "returns the error when impl returns an error", %{user_session: user_session} do
+      expect(Setlistify.AppleMusic.API.MockClient, :add_tracks_to_playlist, 1, fn _session,
+                                                                                  _playlist_id,
+                                                                                  _tracks ->
+        {:error, :rate_limited}
+      end)
+
+      assert {:error, :rate_limited} =
+               API.add_tracks_to_playlist(user_session, "p.playlist-1", [
+                 "am:track:abc"
+               ])
+    end
+  end
+
   describe "search_for_track/3" do
     test "returns the full error tuple when impl returns an error", %{
       user_session: user_session

--- a/test/setlistify/spotify/api_test.exs
+++ b/test/setlistify/spotify/api_test.exs
@@ -26,6 +26,59 @@ defmodule Setlistify.Spotify.APITest do
     {:ok, user_session: user_session}
   end
 
+  describe "create_playlist/3" do
+    test "delegates to the impl and returns the result", %{user_session: user_session} do
+      expect(Setlistify.Spotify.API.MockClient, :create_playlist, 1, fn _session,
+                                                                        _name,
+                                                                        _description ->
+        {:ok, %{id: "playlist-1", external_url: "https://open.spotify.com/playlist/1"}}
+      end)
+
+      assert {:ok, %{id: "playlist-1", external_url: "https://open.spotify.com/playlist/1"}} =
+               API.create_playlist(user_session, "My Setlist", "Songs from a concert")
+    end
+
+    test "returns the error when impl returns an error", %{user_session: user_session} do
+      expect(Setlistify.Spotify.API.MockClient, :create_playlist, 1, fn _session,
+                                                                        _name,
+                                                                        _description ->
+        {:error, :unauthorized}
+      end)
+
+      assert {:error, :unauthorized} =
+               API.create_playlist(user_session, "My Setlist", "Songs from a concert")
+    end
+  end
+
+  describe "add_tracks_to_playlist/3" do
+    test "delegates to the impl and returns the result", %{user_session: user_session} do
+      expect(Setlistify.Spotify.API.MockClient, :add_tracks_to_playlist, 1, fn _session,
+                                                                               _playlist_id,
+                                                                               _tracks ->
+        {:ok, :tracks_added}
+      end)
+
+      assert {:ok, :tracks_added} =
+               API.add_tracks_to_playlist(user_session, "playlist-1", [
+                 "spotify:track:abc",
+                 "spotify:track:def"
+               ])
+    end
+
+    test "returns the error when impl returns an error", %{user_session: user_session} do
+      expect(Setlistify.Spotify.API.MockClient, :add_tracks_to_playlist, 1, fn _session,
+                                                                               _playlist_id,
+                                                                               _tracks ->
+        {:error, :rate_limited}
+      end)
+
+      assert {:error, :rate_limited} =
+               API.add_tracks_to_playlist(user_session, "playlist-1", [
+                 "spotify:track:abc"
+               ])
+    end
+  end
+
   describe "search_for_track/3" do
     test "returns the full error tuple when impl returns an error", %{
       user_session: user_session


### PR DESCRIPTION
## Summary
- Adds delegation and error pass-through tests for `create_playlist/3` and `add_tracks_to_playlist/3` in both `Setlistify.Spotify.APITest` and `Setlistify.AppleMusic.APITest`
- Previously only `search_for_track/3` had wrapper-level test coverage; these two functions were only tested at the ExternalClient level
- Uses the same Hammox mock patterns already established in each test file

## Test plan
- [x] `mix test test/setlistify/spotify/api_test.exs` passes (6 tests)
- [x] `mix test test/setlistify/apple_music/api_test.exs` passes (7 tests)
- [x] Full suite passes: 237 tests, 1 doctest, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)