### PR TITLE
refactor: extract shared session registry helpers (ADR-003 Phase 4)

### DIFF
--- a/lib/setlistify/apple_music/session_manager.ex
+++ b/lib/setlistify/apple_music/session_manager.ex
@@ -16,6 +16,7 @@ defmodule Setlistify.AppleMusic.SessionManager do
   @behaviour Setlistify.UserSessionManager
 
   alias Setlistify.AppleMusic.UserSession
+  alias Setlistify.SessionRegistry
 
   @impl Setlistify.UserSessionManager
   def start_link({user_id, %UserSession{} = session}) do
@@ -26,7 +27,9 @@ defmodule Setlistify.AppleMusic.SessionManager do
         {"session.operation", "start"}
       ])
 
-      case GenServer.start_link(__MODULE__, session, name: via_tuple(user_id)) do
+      case GenServer.start_link(__MODULE__, session,
+             name: SessionRegistry.via_tuple(:apple_music, user_id)
+           ) do
         {:ok, pid} = result ->
           Logger.info("Apple Music session manager started", %{
             user_id: user_id,
@@ -61,7 +64,7 @@ defmodule Setlistify.AppleMusic.SessionManager do
         {"session.operation", "get"}
       ])
 
-      case lookup(user_id) do
+      case SessionRegistry.lookup(:apple_music, user_id) do
         {:ok, pid} ->
           result = {:ok, GenServer.call(pid, :get_session)}
           OpenTelemetry.Tracer.set_status(:ok, "")
@@ -83,7 +86,7 @@ defmodule Setlistify.AppleMusic.SessionManager do
         {"session.operation", "stop"}
       ])
 
-      case lookup(user_id) do
+      case SessionRegistry.lookup(:apple_music, user_id) do
         {:ok, pid} ->
           GenServer.stop(pid, :normal)
           Logger.info("Apple Music session manager stopped", %{user_id: user_id})
@@ -97,19 +100,11 @@ defmodule Setlistify.AppleMusic.SessionManager do
     end
   end
 
-  def lookup(user_id) do
-    case Registry.lookup(Setlistify.UserSessionRegistry, {:apple_music, user_id}) do
-      [{pid, _}] -> {:ok, pid}
-      [] -> :error
-    end
-  end
+  def lookup(user_id), do: SessionRegistry.lookup(:apple_music, user_id)
 
   @impl true
   def init(%UserSession{} = session), do: {:ok, session}
 
   @impl true
   def handle_call(:get_session, _from, session), do: {:reply, session, session}
-
-  defp via_tuple(user_id),
-    do: {:via, Registry, {Setlistify.UserSessionRegistry, {:apple_music, user_id}}}
 end

--- a/lib/setlistify/session_registry.ex
+++ b/lib/setlistify/session_registry.ex
@@ -1,0 +1,43 @@
+defmodule Setlistify.SessionRegistry do
+  @moduledoc """
+  Shared registry helpers for provider session managers.
+
+  Both `Spotify.SessionManager` and `AppleMusic.SessionManager` register
+  processes in `Setlistify.UserSessionRegistry` under a `{provider, user_id}`
+  key. This module centralises the `via_tuple` and `lookup` logic so each
+  provider doesn't duplicate it.
+  """
+
+  @registry Setlistify.UserSessionRegistry
+
+  @doc """
+  Returns a `:via` tuple for registering or naming a process.
+
+  ## Examples
+
+      iex> Setlistify.SessionRegistry.via_tuple(:spotify, "user_1")
+      {:via, Registry, {Setlistify.UserSessionRegistry, {:spotify, "user_1"}}}
+  """
+  @spec via_tuple(atom(), binary()) :: {:via, Registry, {module(), {atom(), binary()}}}
+  def via_tuple(provider, user_id) do
+    {:via, Registry, {@registry, {provider, user_id}}}
+  end
+
+  @doc """
+  Looks up a session manager process by provider and user ID.
+
+  Returns `{:ok, pid}` if found, `:error` otherwise.
+
+  ## Examples
+
+      iex> Setlistify.SessionRegistry.lookup(:spotify, "nonexistent")
+      :error
+  """
+  @spec lookup(atom(), binary()) :: {:ok, pid()} | :error
+  def lookup(provider, user_id) do
+    case Registry.lookup(@registry, {provider, user_id}) do
+      [{pid, _}] -> {:ok, pid}
+      [] -> :error
+    end
+  end
+end

--- a/lib/setlistify/spotify/session_manager.ex
+++ b/lib/setlistify/spotify/session_manager.ex
@@ -92,6 +92,7 @@ defmodule Setlistify.Spotify.SessionManager do
 
   @behaviour Setlistify.UserSessionManager
 
+  alias Setlistify.SessionRegistry
   alias Setlistify.Spotify.API
   alias Setlistify.Spotify.UserSession
 
@@ -110,7 +111,7 @@ defmodule Setlistify.Spotify.SessionManager do
         {"session.operation", "start"}
       ])
 
-      name = via_tuple(user_id)
+      name = SessionRegistry.via_tuple(:spotify, user_id)
 
       case GenServer.start_link(__MODULE__, {user_id, initial_tokens_or_session}, name: name) do
         {:ok, pid} = result ->
@@ -139,7 +140,7 @@ defmodule Setlistify.Spotify.SessionManager do
         {"session.operation", "get_token"}
       ])
 
-      case lookup(user_id) do
+      case SessionRegistry.lookup(:spotify, user_id) do
         {:ok, pid} ->
           result = GenServer.call(pid, :get_token)
 
@@ -172,7 +173,7 @@ defmodule Setlistify.Spotify.SessionManager do
         {"session.operation", "refresh"}
       ])
 
-      case lookup(user_id) do
+      case SessionRegistry.lookup(:spotify, user_id) do
         {:ok, pid} ->
           result = GenServer.call(pid, :refresh_session)
 
@@ -210,7 +211,7 @@ defmodule Setlistify.Spotify.SessionManager do
         {"session.operation", "get"}
       ])
 
-      case lookup(user_id) do
+      case SessionRegistry.lookup(:spotify, user_id) do
         {:ok, pid} ->
           result = GenServer.call(pid, :get_session)
 
@@ -240,7 +241,7 @@ defmodule Setlistify.Spotify.SessionManager do
         {"session.operation", "stop"}
       ])
 
-      case lookup(user_id) do
+      case SessionRegistry.lookup(:spotify, user_id) do
         {:ok, pid} ->
           result = GenServer.stop(pid, :normal)
           Logger.info("Session manager stopped", %{user_id: user_id})
@@ -375,20 +376,11 @@ defmodule Setlistify.Spotify.SessionManager do
 
   # Helper functions
 
-  defp via_tuple(user_id) do
-    {:via, Registry, {Setlistify.UserSessionRegistry, {:spotify, user_id}}}
-  end
-
   @doc """
   Looks up a token manager process by user ID.
   Returns {:ok, pid} if found, :error otherwise.
   """
-  def lookup(user_id) do
-    case Registry.lookup(Setlistify.UserSessionRegistry, {:spotify, user_id}) do
-      [{pid, _}] -> {:ok, pid}
-      [] -> :error
-    end
-  end
+  def lookup(user_id), do: SessionRegistry.lookup(:spotify, user_id)
 
   defp schedule_refresh(after_seconds) when after_seconds > 0 do
     Process.send_after(self(), :refresh_token, :timer.seconds(after_seconds))

--- a/lib/setlistify/spotify/session_supervisor.ex
+++ b/lib/setlistify/spotify/session_supervisor.ex
@@ -44,6 +44,15 @@ defmodule Setlistify.Spotify.SessionSupervisor do
           OpenTelemetry.Tracer.set_status(:ok, "")
           result
 
+        {:error, {:already_started, pid}} ->
+          Logger.info("User token process already running", %{
+            user_id: user_id,
+            pid: inspect(pid)
+          })
+
+          OpenTelemetry.Tracer.set_status(:ok, "")
+          {:ok, pid}
+
         {:error, reason} = error ->
           Logger.error("Failed to start user token process", %{user_id: user_id, error: reason})
           OpenTelemetry.Tracer.set_status(:error, "Failed to start child: #{inspect(reason)}")

--- a/lib/setlistify_web/plugs/restore_spotify_token.ex
+++ b/lib/setlistify_web/plugs/restore_spotify_token.ex
@@ -24,26 +24,18 @@ defmodule SetlistifyWeb.Plugs.RestoreSpotifyToken do
 
   defp do_call(conn) do
     user_id = get_session(conn, :user_id)
-    refresh_token = get_session(conn, :refresh_token)
+    encrypted_token = get_session(conn, :refresh_token)
 
     with "spotify" <- get_session(conn, :auth_provider),
          user_id when not is_nil(user_id) <- user_id,
          {:error, :not_found} <- SessionManager.get_session(user_id),
-         encrypted_token when not is_nil(encrypted_token) <- refresh_token,
-         {:ok, refresh_token} <-
-           Phoenix.Token.verify(
-             SetlistifyWeb.Endpoint,
-             TokenSalts.spotify_refresh_token(),
-             encrypted_token,
-             max_age: 86400 * 30
-           ) do
+         {:ok, refresh_token} <- decrypt_token(encrypted_token) do
       case API.refresh_to_user_session(refresh_token) do
         {:ok, user_session} ->
           {:ok, _pid} = SessionSupervisor.start_user_token(user_id, user_session)
           conn
 
         {:error, _reason} ->
-          # If refresh fails, clear the session but continue with the request
           conn
           |> clear_session()
           |> Phoenix.Controller.put_flash(
@@ -54,5 +46,13 @@ defmodule SetlistifyWeb.Plugs.RestoreSpotifyToken do
     else
       _ -> conn
     end
+  end
+
+  defp decrypt_token(nil), do: {:error, :missing}
+
+  defp decrypt_token(encrypted) do
+    Phoenix.Token.verify(SetlistifyWeb.Endpoint, TokenSalts.spotify_refresh_token(), encrypted,
+      max_age: 86_400 * 30
+    )
   end
 end


### PR DESCRIPTION
## Summary
- **Registry helpers extraction**: Created `Setlistify.SessionRegistry` with `via_tuple/2` and `lookup/2`, replacing duplicated private `via_tuple/1` and `lookup/1` in both `Spotify.SessionManager` and `AppleMusic.SessionManager`. Both session managers now delegate through the shared module.
- **`already_started` handling alignment**: Added `{:error, {:already_started, pid}}` handling to `Spotify.SessionSupervisor.start_user_token/2` to match `AppleMusic.SessionSupervisor`, guarding against a race where two callers try to start a session for the same user concurrently.
- **`decrypt_token/1` extraction**: Refactored `RestoreSpotifyToken` plug to extract a `decrypt_token/1` helper (with `nil` guard clause) matching the pattern already used in `RestoreAppleMusicToken`.

## Test plan
- [x] `mix compile --warnings-as-errors` passes with no warnings
- [x] `mix test` passes (229 tests, 1 doctest, 0 failures)
- [x] `mix dialyzer` passes with 0 errors
- [ ] Verify Spotify login/session restore flow in browser
- [ ] Verify Apple Music login/session restore flow in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)