### PR TITLE
Replace Jason with built-in JSON module

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -28,8 +28,8 @@ config :opentelemetry, :resource,
     namespace: "setlistify"
   ]
 
-# Use Jason for JSON parsing in Phoenix
-config :phoenix, :json_library, Jason
+# Use Elixir's built-in JSON module for Phoenix
+config :phoenix, :json_library, JSON
 
 # Configures the endpoint
 config :setlistify, SetlistifyWeb.Endpoint,

--- a/lib/setlistify/apple_music/jwt.ex
+++ b/lib/setlistify/apple_music/jwt.ex
@@ -15,10 +15,10 @@ defmodule Setlistify.AppleMusic.JWT do
           String.t()
   def sign(claims, pem, kid, iss) do
     header_b64 =
-      %{"alg" => "ES256", "kid" => kid} |> Jason.encode!() |> Base.url_encode64(padding: false)
+      %{"alg" => "ES256", "kid" => kid} |> JSON.encode!() |> Base.url_encode64(padding: false)
 
     payload_b64 =
-      claims |> Map.put("iss", iss) |> Jason.encode!() |> Base.url_encode64(padding: false)
+      claims |> Map.put("iss", iss) |> JSON.encode!() |> Base.url_encode64(padding: false)
 
     signing_input = header_b64 <> "." <> payload_b64
 

--- a/lib/setlistify/loki_logger.ex
+++ b/lib/setlistify/loki_logger.ex
@@ -202,7 +202,7 @@ defmodule Setlistify.LokiLogger do
     headers = [{"content-type", "application/json"}]
     headers = if auth_header, do: [auth_header | headers], else: headers
 
-    body = Jason.encode!(payload)
+    body = JSON.encode!(payload)
 
     case Req.post(url, body: body, headers: headers) do
       {:ok, %{status: status}} when status in 200..299 ->

--- a/lib/setlistify_web/components/core_components.ex
+++ b/lib/setlistify_web/components/core_components.ex
@@ -778,7 +778,7 @@ defmodule SetlistifyWeb.CoreComponents do
         id="rotating-text"
         class={[@computed_text_classes]}
         phx-hook="RotatingText"
-        data-texts={Jason.encode!(@texts)}
+        data-texts={JSON.encode!(@texts)}
       >
         <span>{List.first(@texts)}</span>
       </div>

--- a/mix.exs
+++ b/mix.exs
@@ -53,7 +53,6 @@ defmodule Setlistify.MixProject do
       {:gettext, "~> 0.20"},
       {:hammox, "~> 0.7", only: :test},
       {:heroicons, "~> 0.5"},
-      {:jason, "~> 1.2"},
       {:logger_backends, "~> 1.0"},
       {:phoenix, "~> 1.8", override: true},
       {:phoenix_ecto, "~> 4.4"},

--- a/test/setlistify/apple_music/api/external_client_test.exs
+++ b/test/setlistify/apple_music/api/external_client_test.exs
@@ -114,7 +114,7 @@ defmodule Setlistify.AppleMusic.API.ExternalClientTest do
         %{request_path: "/v1/me/library/playlists", method: "POST"} = conn ->
           {:ok, body, _} = Plug.Conn.read_body(conn)
 
-          assert Jason.decode!(body) == %{
+          assert JSON.decode!(body) == %{
                    "attributes" => %{
                      "name" => "My Playlist",
                      "description" => "A description"
@@ -189,7 +189,7 @@ defmodule Setlistify.AppleMusic.API.ExternalClientTest do
       Req.Test.stub(MyAppleMusicStub, fn
         %{request_path: "/v1/me/library/playlists/p.abc123/tracks", method: "POST"} = conn ->
           {:ok, body, _} = Plug.Conn.read_body(conn)
-          data = Jason.decode!(body)["data"]
+          data = JSON.decode!(body)["data"]
           assert length(data) == 2
           assert Enum.all?(data, &(&1["type"] == "songs"))
           Plug.Conn.send_resp(conn, 204, "")

--- a/test/setlistify/apple_music/jwt_test.exs
+++ b/test/setlistify/apple_music/jwt_test.exs
@@ -35,7 +35,7 @@ defmodule Setlistify.AppleMusic.JWTTest do
       token = JWT.sign(%{"iat" => 1_000, "exp" => 2_000}, @test_private_pem, @kid, @iss)
 
       [header_b64 | _] = String.split(token, ".")
-      header = header_b64 |> Base.url_decode64!(padding: false) |> Jason.decode!()
+      header = header_b64 |> Base.url_decode64!(padding: false) |> JSON.decode!()
 
       assert header["alg"] == "ES256"
       assert header["kid"] == @kid
@@ -46,7 +46,7 @@ defmodule Setlistify.AppleMusic.JWTTest do
       token = JWT.sign(claims, @test_private_pem, @kid, @iss)
 
       [_, payload_b64 | _] = String.split(token, ".")
-      decoded = payload_b64 |> Base.url_decode64!(padding: false) |> Jason.decode!()
+      decoded = payload_b64 |> Base.url_decode64!(padding: false) |> JSON.decode!()
 
       assert decoded["iss"] == @iss
       assert decoded["iat"] == 1_000

--- a/test/setlistify/setlist_fm/api/external_client_test.exs
+++ b/test/setlistify/setlist_fm/api/external_client_test.exs
@@ -17,7 +17,7 @@ defmodule Setlistify.SetlistFm.API.ExternalClientTest do
 
         conn
         |> Plug.Conn.put_resp_header("content-type", "application/json")
-        |> Plug.Conn.send_resp(200, Jason.encode!(Jason.decode!(@search_response)))
+        |> Plug.Conn.send_resp(200, JSON.encode!(JSON.decode!(@search_response)))
     end)
 
     assert {:ok, %{setlists: setlists, pagination: pagination}} =
@@ -76,7 +76,7 @@ defmodule Setlistify.SetlistFm.API.ExternalClientTest do
 
         conn
         |> Plug.Conn.put_resp_header("content-type", "application/json")
-        |> Plug.Conn.send_resp(200, Jason.encode!(response))
+        |> Plug.Conn.send_resp(200, JSON.encode!(response))
     end)
 
     assert {:ok, %{setlists: setlists, pagination: pagination}} =
@@ -137,7 +137,7 @@ defmodule Setlistify.SetlistFm.API.ExternalClientTest do
       %{request_path: "/rest/1.0/search/setlists", method: "GET"} = conn ->
         conn
         |> Plug.Conn.put_resp_header("content-type", "application/json")
-        |> Plug.Conn.send_resp(200, Jason.encode!(response))
+        |> Plug.Conn.send_resp(200, JSON.encode!(response))
     end)
 
     assert {:ok, %{setlists: [uk_event, canada_event]}} = ExternalClient.search("beatles", 1)
@@ -177,7 +177,7 @@ defmodule Setlistify.SetlistFm.API.ExternalClientTest do
       %{request_path: "/rest/1.0/search/setlists", method: "GET"} = conn ->
         conn
         |> Plug.Conn.put_resp_header("content-type", "application/json")
-        |> Plug.Conn.send_resp(200, Jason.encode!(response))
+        |> Plug.Conn.send_resp(200, JSON.encode!(response))
     end)
 
     assert {:ok, %{setlists: [event]}} = ExternalClient.search("test", 1)
@@ -310,7 +310,7 @@ defmodule Setlistify.SetlistFm.API.ExternalClientTest do
       %{request_path: "/rest/1.0/search/setlists", method: "GET"} = conn ->
         conn
         |> Plug.Conn.put_resp_header("content-type", "application/json")
-        |> Plug.Conn.send_resp(200, Jason.encode!(response))
+        |> Plug.Conn.send_resp(200, JSON.encode!(response))
     end)
 
     assert {:ok, %{setlists: [no_songs, one_set, multiple_sets, set_with_encore]}} =
@@ -418,7 +418,7 @@ defmodule Setlistify.SetlistFm.API.ExternalClientTest do
       %{request_path: "/rest/1.0/search/setlists", method: "GET"} = conn ->
         conn
         |> Plug.Conn.put_resp_header("content-type", "application/json")
-        |> Plug.Conn.send_resp(200, Jason.encode!(response))
+        |> Plug.Conn.send_resp(200, JSON.encode!(response))
     end)
 
     assert {:ok, %{setlists: [result]}} = ExternalClient.search("test artist", 1)
@@ -441,7 +441,7 @@ defmodule Setlistify.SetlistFm.API.ExternalClientTest do
 
       conn
       |> Plug.Conn.put_resp_header("content-type", "application/json")
-      |> Plug.Conn.send_resp(200, Jason.encode!(Jason.decode!(@get_response)))
+      |> Plug.Conn.send_resp(200, JSON.encode!(JSON.decode!(@get_response)))
     end)
 
     assert {:ok, result} = ExternalClient.get_setlist(id)
@@ -466,7 +466,7 @@ defmodule Setlistify.SetlistFm.API.ExternalClientTest do
         %{request_path: "/rest/1.0/search/setlists", method: "GET"} = conn ->
           conn
           |> Plug.Conn.put_resp_header("content-type", "application/json")
-          |> Plug.Conn.send_resp(500, Jason.encode!(%{error: "Internal Server Error"}))
+          |> Plug.Conn.send_resp(500, JSON.encode!(%{error: "Internal Server Error"}))
       end)
 
       assert {:error, {:api_error, _}} = ExternalClient.search("test artist", 1)
@@ -477,7 +477,7 @@ defmodule Setlistify.SetlistFm.API.ExternalClientTest do
         %{request_path: "/rest/1.0/search/setlists", method: "GET"} = conn ->
           conn
           |> Plug.Conn.put_resp_header("content-type", "application/json")
-          |> Plug.Conn.send_resp(429, Jason.encode!(%{error: "Rate Limited"}))
+          |> Plug.Conn.send_resp(429, JSON.encode!(%{error: "Rate Limited"}))
       end)
 
       assert {:error, {:api_error, "HTTP 429"}} = ExternalClient.search("test artist", 1)
@@ -500,7 +500,7 @@ defmodule Setlistify.SetlistFm.API.ExternalClientTest do
         %{request_path: "/rest/1.0/setlist/" <> ^id, method: "GET"} = conn ->
           conn
           |> Plug.Conn.put_resp_header("content-type", "application/json")
-          |> Plug.Conn.send_resp(404, Jason.encode!(%{error: "Not Found"}))
+          |> Plug.Conn.send_resp(404, JSON.encode!(%{error: "Not Found"}))
       end)
 
       assert {:error, :not_found} = ExternalClient.get_setlist(id)
@@ -513,7 +513,7 @@ defmodule Setlistify.SetlistFm.API.ExternalClientTest do
         %{request_path: "/rest/1.0/setlist/" <> ^id, method: "GET"} = conn ->
           conn
           |> Plug.Conn.put_resp_header("content-type", "application/json")
-          |> Plug.Conn.send_resp(503, Jason.encode!(%{error: "Service Unavailable"}))
+          |> Plug.Conn.send_resp(503, JSON.encode!(%{error: "Service Unavailable"}))
       end)
 
       assert {:error, :network_error} = ExternalClient.get_setlist(id)

--- a/test/setlistify/spotify/api/external_client_test.exs
+++ b/test/setlistify/spotify/api/external_client_test.exs
@@ -42,7 +42,7 @@ defmodule Setlistify.Spotify.Api.ExternalClientTest do
         %{request_path: "/v1/search", method: "GET"} = conn ->
           conn
           |> Plug.Conn.put_resp_header("content-type", "application/json")
-          |> Plug.Conn.send_resp(200, Jason.encode!(Jason.decode!(@search_response)))
+          |> Plug.Conn.send_resp(200, JSON.encode!(JSON.decode!(@search_response)))
       end)
 
       result = ExternalClient.search_for_track(user_session, "some artist", "some track")
@@ -57,7 +57,7 @@ defmodule Setlistify.Spotify.Api.ExternalClientTest do
 
           conn
           |> Plug.Conn.put_resp_header("content-type", "application/json")
-          |> Plug.Conn.send_resp(200, Jason.encode!(response))
+          |> Plug.Conn.send_resp(200, JSON.encode!(response))
       end)
 
       ExUnit.CaptureLog.capture_log(fn ->
@@ -76,7 +76,7 @@ defmodule Setlistify.Spotify.Api.ExternalClientTest do
           # Assert the request payload is correct
           {:ok, body, _} = Plug.Conn.read_body(conn)
 
-          assert Jason.decode!(body) == %{
+          assert JSON.decode!(body) == %{
                    "name" => "Test Playlist",
                    "description" => "Test Description",
                    "public" => false
@@ -84,7 +84,7 @@ defmodule Setlistify.Spotify.Api.ExternalClientTest do
 
           conn
           |> Plug.Conn.put_resp_header("content-type", "application/json")
-          |> Plug.Conn.send_resp(201, Jason.encode!(Jason.decode!(@create_playlist_response)))
+          |> Plug.Conn.send_resp(201, JSON.encode!(JSON.decode!(@create_playlist_response)))
       end)
 
       assert {:ok, playlist_response} =
@@ -106,13 +106,13 @@ defmodule Setlistify.Spotify.Api.ExternalClientTest do
           # Assert the request payload contains the track URIs
           {:ok, body, _} = Plug.Conn.read_body(conn)
 
-          assert Jason.decode!(body) == %{
+          assert JSON.decode!(body) == %{
                    "uris" => track_uris
                  }
 
           conn
           |> Plug.Conn.put_resp_header("content-type", "application/json")
-          |> Plug.Conn.send_resp(201, Jason.encode!(Jason.decode!(@add_tracks_response)))
+          |> Plug.Conn.send_resp(201, JSON.encode!(JSON.decode!(@add_tracks_response)))
       end)
 
       assert {:ok, :tracks_added} =
@@ -191,7 +191,7 @@ defmodule Setlistify.Spotify.Api.ExternalClientTest do
 
           conn
           |> Plug.Conn.put_resp_header("content-type", "application/json")
-          |> Plug.Conn.send_resp(200, Jason.encode!(response))
+          |> Plug.Conn.send_resp(200, JSON.encode!(response))
         end
       )
 
@@ -223,7 +223,7 @@ defmodule Setlistify.Spotify.Api.ExternalClientTest do
 
           conn
           |> Plug.Conn.put_resp_header("content-type", "application/json")
-          |> Plug.Conn.send_resp(200, Jason.encode!(response))
+          |> Plug.Conn.send_resp(200, JSON.encode!(response))
         end
       )
 
@@ -274,7 +274,7 @@ defmodule Setlistify.Spotify.Api.ExternalClientTest do
 
           conn
           |> Plug.Conn.put_resp_header("content-type", "application/json")
-          |> Plug.Conn.send_resp(200, Jason.encode!(response))
+          |> Plug.Conn.send_resp(200, JSON.encode!(response))
         end
       )
 
@@ -291,7 +291,7 @@ defmodule Setlistify.Spotify.Api.ExternalClientTest do
 
           conn
           |> Plug.Conn.put_resp_header("content-type", "application/json")
-          |> Plug.Conn.send_resp(200, Jason.encode!(profile))
+          |> Plug.Conn.send_resp(200, JSON.encode!(profile))
         end
       )
 
@@ -331,7 +331,7 @@ defmodule Setlistify.Spotify.Api.ExternalClientTest do
 
           conn
           |> Plug.Conn.put_resp_header("content-type", "application/json")
-          |> Plug.Conn.send_resp(200, Jason.encode!(response))
+          |> Plug.Conn.send_resp(200, JSON.encode!(response))
         end
       )
 
@@ -378,7 +378,7 @@ defmodule Setlistify.Spotify.Api.ExternalClientTest do
 
           conn
           |> Plug.Conn.put_resp_header("content-type", "application/json")
-          |> Plug.Conn.send_resp(200, Jason.encode!(response))
+          |> Plug.Conn.send_resp(200, JSON.encode!(response))
         end
       )
 
@@ -397,7 +397,7 @@ defmodule Setlistify.Spotify.Api.ExternalClientTest do
 
           conn
           |> Plug.Conn.put_resp_header("content-type", "application/json")
-          |> Plug.Conn.send_resp(200, Jason.encode!(profile))
+          |> Plug.Conn.send_resp(200, JSON.encode!(profile))
         end
       )
 
@@ -433,7 +433,7 @@ defmodule Setlistify.Spotify.Api.ExternalClientTest do
 
           conn
           |> Plug.Conn.put_resp_header("content-type", "application/json")
-          |> Plug.Conn.send_resp(200, Jason.encode!(response))
+          |> Plug.Conn.send_resp(200, JSON.encode!(response))
         end
       )
 
@@ -467,7 +467,7 @@ defmodule Setlistify.Spotify.Api.ExternalClientTest do
 
           conn
           |> Plug.Conn.put_resp_header("content-type", "application/json")
-          |> Plug.Conn.send_resp(400, Jason.encode!(response))
+          |> Plug.Conn.send_resp(400, JSON.encode!(response))
         end
       )
 
@@ -491,7 +491,7 @@ defmodule Setlistify.Spotify.Api.ExternalClientTest do
 
           conn
           |> Plug.Conn.put_resp_header("content-type", "application/json")
-          |> Plug.Conn.send_resp(401, Jason.encode!(response))
+          |> Plug.Conn.send_resp(401, JSON.encode!(response))
         end
       )
 
@@ -567,7 +567,7 @@ defmodule Setlistify.Spotify.Api.ExternalClientTest do
           )
           |> Plug.Conn.send_resp(
             401,
-            Jason.encode!(%{
+            JSON.encode!(%{
               "error" => %{"message" => "The access token expired", "status" => 401}
             })
           )
@@ -583,7 +583,7 @@ defmodule Setlistify.Spotify.Api.ExternalClientTest do
 
           conn
           |> Plug.Conn.put_resp_header("content-type", "application/json")
-          |> Plug.Conn.send_resp(201, Jason.encode!(Jason.decode!(@create_playlist_response)))
+          |> Plug.Conn.send_resp(201, JSON.encode!(JSON.decode!(@create_playlist_response)))
         end
       )
 
@@ -643,7 +643,7 @@ defmodule Setlistify.Spotify.Api.ExternalClientTest do
           )
           |> Plug.Conn.send_resp(
             401,
-            Jason.encode!(%{
+            JSON.encode!(%{
               "error" => %{"message" => "The access token expired", "status" => 401}
             })
           )
@@ -712,7 +712,7 @@ defmodule Setlistify.Spotify.Api.ExternalClientTest do
           )
           |> Plug.Conn.send_resp(
             401,
-            Jason.encode!(%{
+            JSON.encode!(%{
               "error" => %{"message" => "The access token expired", "status" => 401}
             })
           )
@@ -728,7 +728,7 @@ defmodule Setlistify.Spotify.Api.ExternalClientTest do
 
           conn
           |> Plug.Conn.put_resp_header("content-type", "application/json")
-          |> Plug.Conn.send_resp(201, Jason.encode!(Jason.decode!(@add_tracks_response)))
+          |> Plug.Conn.send_resp(201, JSON.encode!(JSON.decode!(@add_tracks_response)))
         end
       )
 
@@ -787,7 +787,7 @@ defmodule Setlistify.Spotify.Api.ExternalClientTest do
           )
           |> Plug.Conn.send_resp(
             401,
-            Jason.encode!(%{
+            JSON.encode!(%{
               "error" => %{"message" => "The access token expired", "status" => 401}
             })
           )
@@ -853,7 +853,7 @@ defmodule Setlistify.Spotify.Api.ExternalClientTest do
           )
           |> Plug.Conn.send_resp(
             401,
-            Jason.encode!(%{
+            JSON.encode!(%{
               "error" => %{"message" => "The access token expired", "status" => 401}
             })
           )
@@ -867,7 +867,7 @@ defmodule Setlistify.Spotify.Api.ExternalClientTest do
         fn %{request_path: "/v1/search", method: "GET"} = conn ->
           conn
           |> Plug.Conn.put_resp_header("content-type", "application/json")
-          |> Plug.Conn.send_resp(200, Jason.encode!(Jason.decode!(@search_response)))
+          |> Plug.Conn.send_resp(200, JSON.encode!(JSON.decode!(@search_response)))
         end
       )
 


### PR DESCRIPTION
## Summary

- Replace all direct `Jason.encode!/decode!` calls with Elixir's built-in `JSON` module (available since 1.18)
- Update Phoenix `json_library` config from `Jason` to `JSON`
- Remove `jason` as a direct dependency (remains transitively via other deps)

Closes issue #108

## Test plan

- [x] `mix compile` — no errors
- [x] `mix test` — all 254 tests pass
- [x] `mix credo --strict` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)