### PR TITLE
Migrate test HTML parsing from Floki to lazy_html

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -48,7 +48,6 @@ defmodule Setlistify.MixProject do
       {:esbuild, "~> 0.5", runtime: Mix.env() == :dev},
       {:ex_doc, "~> 0.30", only: :dev, runtime: false},
       {:finch, "~> 0.13"},
-      {:floki, ">= 0.30.0", only: :test},
       {:lazy_html, "~> 0.1", only: :test},
       {:gettext, "~> 0.20"},
       {:hammox, "~> 0.7", only: :test},

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -38,7 +38,7 @@ defmodule SetlistifyWeb.ConnCase do
 
       def assert_has_element(html, selector, opts \\ []) do
         expected = Keyword.get(opts, :count, 1)
-        actual = html |> Floki.parse_document!() |> Floki.find(selector) |> length()
+        actual = html |> LazyHTML.from_document() |> LazyHTML.query(selector) |> Enum.count()
 
         assert expected == actual,
                "expected #{expected} elements matching #{selector}, found #{actual}"


### PR DESCRIPTION
## Summary

- Replace `Floki.parse_document!/1` + `Floki.find/2` with `LazyHTML.from_document/1` + `LazyHTML.query/2` in `test/support/conn_case.ex`
- Remove `floki` from test dependencies (no longer needed directly or transitively)

Closes issue #112

## Test plan

- [x] `mix compile` — no errors
- [x] `mix test` — all 254 tests pass
- [x] `mix credo --strict` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)