### PR TITLE
Fix Fly deploy by updating Dockerfile to Elixir 1.19/OTP 28

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,13 @@
 # This file is based on these images:
 #
 #   - https://hub.docker.com/r/hexpm/elixir/tags - for the build image
-#   - https://hub.docker.com/_/debian?tab=tags&page=1&name=bullseye-20250428-slim - for the release image
+#   - https://hub.docker.com/_/debian?tab=tags&page=1&name=bullseye-20260406-slim - for the release image
 #   - https://pkgs.org/ - resource for finding needed packages
-#   - Ex: hexpm/elixir:1.17.3-erlang-27.1.3-debian-bullseye-20250428-slim
+#   - Ex: hexpm/elixir:1.19.5-erlang-28.4.1-debian-bullseye-20260406-slim
 #
-ARG ELIXIR_VERSION=1.17.3
-ARG OTP_VERSION=27.1.3
-ARG DEBIAN_VERSION=bullseye-20250428-slim
+ARG ELIXIR_VERSION=1.19.5
+ARG OTP_VERSION=28.4.1
+ARG DEBIAN_VERSION=bullseye-20260406-slim
 
 ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
 ARG RUNNER_IMAGE="debian:${DEBIAN_VERSION}"


### PR DESCRIPTION
## Summary

- Update Dockerfile `ELIXIR_VERSION` from 1.17.3 to 1.19.5
- Update Dockerfile `OTP_VERSION` from 27.1.3 to 28.4.1
- Update `DEBIAN_VERSION` to matching available image tag

The Dockerfile was missed during the Elixir 1.19.5/OTP 28 upgrade in #110, causing deploys to fail with a version mismatch: the Docker image built with Elixir 1.17.3 but `mix.exs` requires `~> 1.19`.

## Test plan

- [ ] Verify CI/deploy workflow passes with updated Dockerfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)