### PR TITLE
docs: add AGENTS.md for AI coding assistant guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,102 +1,225 @@
-# AGENTS.md
+This is a web application written using the Phoenix web framework.
 
-This file provides guidance for AI coding assistants working with this repository.
+## Project guidelines
 
-## Commands
+- Use `mix precommit` alias when you are done with all changes and fix any pending issues
+- Use the already included and available `:req` (`Req`) library for HTTP requests, **avoid** `:httpoison`, `:tesla`, and `:httpc`. Req is included by default and is the preferred HTTP client for Phoenix apps
 
-### Setup & Running
+### Phoenix v1.8 guidelines
 
-```shell
-# Initialize the project (first time setup)
-bin/init
+- **Always** begin your LiveView templates with `<Layouts.app flash={@flash} ...>` which wraps all inner content
+- The `SetlistifyWeb.Layouts` module is aliased in `setlistify_web.ex`, so you can use it without needing to alias it again
+- Anytime you run into errors with no `current_scope` assign:
+  - You failed to follow the Authenticated Routes guidelines, or you failed to pass `current_scope` to `<Layouts.app>`
+  - **Always** fix the `current_scope` error by moving your routes to the proper `live_session` and ensure you pass `current_scope` as needed
+- Phoenix v1.8 moved the `<.flash_group>` component to the `Layouts` module. You are **forbidden** from calling `<.flash_group>` outside of the `layouts.ex` module
+- Out of the box, `core_components.ex` imports an `<.icon name="hero-x-mark" class="w-5 h-5"/>` component for hero icons. **Always** use the `<.icon>` component for icons, **never** use `Heroicons` modules or similar
+- **Always** use the imported `<.input>` component for form inputs from `core_components.ex` when available
+- If you override the default input classes (`<.input class="myclass px-2 py-1 rounded-lg">`) with your own values, no default classes are inherited, so your custom classes must fully style the input
 
-# Run the Phoenix server with iex
-bin/server
+### JS and CSS guidelines
 
-# Install dependencies
-mix deps.get
+- **Use Tailwind CSS classes and custom CSS rules** to create polished, responsive, and visually stunning interfaces
+- Tailwind CSS v4 **no longer needs a tailwind.config.js** and uses a new import syntax in `app.css`:
 
-# Compile the project
-mix compile
+      @import "tailwindcss" source(none);
+      @source "../css";
+      @source "../js";
+      @source "../../lib/setlistify_web";
 
-# Run tests
-mix test
+- **Always use and maintain this import syntax** in the app.css file for projects generated with `phx.new`
+- **Never** use `@apply` when writing raw CSS
+- **Always** manually write your own Tailwind-based components instead of using daisyUI for a unique, world-class design
+- Out of the box **only the app.js and app.css bundles are supported**
+  - You cannot reference an external vendored script `src` or link `href` in the layouts
+  - You must import vendor deps into app.js and app.css to use them
+  - **Never write inline `<script>custom js</script>` tags within templates**
 
-# Run a specific test file
-mix test test/path/to/test_file.exs
+### UI/UX & design guidelines
 
-# Run a specific test (line number)
-mix test test/path/to/test_file.exs:123
+- **Produce world-class UI designs** with a focus on usability, aesthetics, and modern design principles
+- Implement **subtle micro-interactions** (e.g., button hover effects, and smooth transitions)
+- Ensure **clean typography, spacing, and layout balance** for a refined, premium look
+- Focus on **delightful details** like hover effects, loading states, and smooth page transitions
 
-# Format code
-mix format
+<!-- usage-rules-start -->
 
-# Static analysis with Dialyzer
-mix dialyzer
-```
+<!-- phoenix:elixir-start -->
+## Elixir guidelines
 
-## Architecture
+- Elixir lists **do not support index based access via the access syntax**
 
-Setlistify is an Elixir/Phoenix application that integrates with:
-1. Setlist.fm API - to fetch artist setlists
-2. Spotify API - to create playlists from setlists
+  **Never do this (invalid)**:
 
-### Key Components
+      i = 0
+      mylist = ["blue", "green"]
+      mylist[i]
 
-#### Setlist.fm Integration
-- `Setlistify.SetlistFm.API` - Interface module with callbacks for searching and fetching setlists
-- `Setlistify.SetlistFm.API.ExternalClient` - Implementation of the API for actual HTTP requests
+  Instead, **always** use `Enum.at`, pattern matching, or `List` for index based list access:
 
-#### Spotify Integration
-- `Setlistify.Spotify.API` - Interface for Spotify API operations (search tracks, create playlists)
-- `Setlistify.Spotify.API.ExternalClient` - Implementation for actual HTTP requests
-- `Setlistify.Spotify.SessionManager` - GenServer for managing user Spotify sessions (tokens)
-- `Setlistify.Spotify.SessionSupervisor` - Supervisor for session management processes
+      i = 0
+      mylist = ["blue", "green"]
+      Enum.at(mylist, i)
 
-#### Token Management
-- Each user has a separate token manager process identified by user ID
-- Tokens are automatically refreshed before they expire
-- Registry and DynamicSupervisor are used to track and manage token processes
+- Elixir variables are immutable, but can be rebound, so for block expressions like `if`, `case`, `cond`, etc.
+  you *must* bind the result of the expression to a variable if you want to use it and you CANNOT rebind the result inside the expression:
 
-#### Web Interface
-- Phoenix LiveView for interactive UI components
-- Main paths:
-  - `/` - Search interface
-  - `/setlist/:id` - View specific setlist
-  - `/playlists` - View playlists
+      # INVALID: we are rebinding inside the `if` and the result never gets assigned
+      if connected?(socket) do
+        socket = assign(socket, :val, val)
+      end
 
-#### Authentication
-- OAuth integration with Spotify
-- Token refreshing handled with GenServer processes
+      # VALID: we rebind the result of the `if` to a new variable
+      socket =
+        if connected?(socket) do
+          assign(socket, :val, val)
+        end
 
-### Testing
+- **Never** nest multiple modules in the same file as it can cause cyclic dependencies and compilation errors
+- **Never** use map access syntax (`changeset[:field]`) on structs as they do not implement the Access behaviour by default. Access struct fields directly (`my_struct.field`) or use higher level APIs where available
+- Elixir's standard library has everything necessary for date and time manipulation. **Never** install additional dependencies unless asked or for date/time parsing (where you can use the `date_time_parser` package)
+- Don't use `String.to_atom/1` on user input (memory leak risk)
+- Predicate function names should not start with `is_` and should end in a question mark
+- Elixir's built-in OTP primitives like `DynamicSupervisor` and `Registry` require names in the child spec, such as `{DynamicSupervisor, name: Setlistify.MyDynamicSup}`, then `DynamicSupervisor.start_child(Setlistify.MyDynamicSup, child_spec)`
+- Use `Task.async_stream(collection, callback, options)` for concurrent enumeration with back-pressure. Usually pass `timeout: :infinity`
 
-The application uses Hammox for mocking:
-- `Setlistify.SetlistFm.API.MockClient` for setlist.fm API
-- `Setlistify.Spotify.API.MockClient` for Spotify API
-- Recommendation: use Hammox for mocks, not Mox. It has the same API as Mox.
+## Mix guidelines
 
-## Environment Configuration
+- Read the docs and options before using tasks (`mix help task_name`)
+- To debug test failures, run `mix test test/my_test.exs` or `mix test --failed`
+- `mix deps.clean --all` is **almost never needed**. **Avoid** using it unless you have good reason
 
-Required environment variables:
-- `SETLIST_FM_API_SECRET` - API key for Setlist.fm
-- `SPOTIFY_CLIENT_ID` - OAuth client ID for Spotify
-- `SPOTIFY_CLIENT_SECRET` - OAuth client secret for Spotify
+## Test guidelines
 
-Optional environment variables for Grafana Cloud observability:
-- `GRAFANA_CLOUD_API_KEY` - API key for Grafana Cloud (shared for all services)
-- `GRAFANA_CLOUD_USER_ID` - User ID for Tempo from Grafana Cloud
-- `GRAFANA_CLOUD_TEMPO_ENDPOINT` - Tempo endpoint for traces
-- `GRAFANA_CLOUD_LOKI_ENDPOINT` - Loki endpoint for logs (must include /loki/api/v1/push)
-- `GRAFANA_CLOUD_LOKI_USER_ID` - User ID for Loki (usually different from Tempo)
-- `GRAFANA_CLOUD_REGION` - Cloud region (defaults to "us-central1")
-- `GRAFANA_CLOUD_ZONE` - Cloud zone (optional)
+- **Always use `start_supervised!/1`** to start processes in tests as it guarantees cleanup between tests
+- **Avoid** `Process.sleep/1` and `Process.alive?/1` in tests
+  - Instead of sleeping to wait for a process to finish, **always** use `Process.monitor/1` and assert on the DOWN message:
 
-These values are automatically loaded from `.env` in development. You can copy `.env.example` to `.env` and fill in the values.
+        ref = Process.monitor(pid)
+        assert_receive {:DOWN, ^ref, :process, ^pid, :normal}
 
-## Development Reminders
+  - Instead of sleeping to synchronize before the next call, **always** use `_ = :sys.get_state/1` to ensure the process has handled prior messages
 
-- Run `mix format` after making changes (includes Styler auto-rewrites)
-- Run `mix credo --strict` to check for static analysis issues
-- Run `mix test` to run all tests
-- Run format frequently to avoid style warnings, especially before planning to commit
+<!-- phoenix:elixir-end -->
+
+<!-- phoenix:phoenix-start -->
+## Phoenix guidelines
+
+- Remember Phoenix router `scope` blocks include an optional alias which is prefixed for all routes within the scope. **Always** be mindful of this to avoid duplicate module prefixes.
+
+- You **never** need to create your own `alias` for route definitions — the `scope` provides the alias:
+
+      scope "/admin", SetlistifyWeb.Admin do
+        pipe_through :browser
+        live "/users", UserLive, :index
+      end
+
+  the `UserLive` route points to `SetlistifyWeb.Admin.UserLive`
+
+- `Phoenix.View` no longer is needed or included with Phoenix, don't use it
+
+<!-- phoenix:phoenix-end -->
+
+<!-- phoenix:html-start -->
+## Phoenix HTML guidelines
+
+- Phoenix templates **always** use `~H` or `.html.heex` files (HEEx), **never** use `~E`
+- **Always** use `Phoenix.Component.form/1` and `Phoenix.Component.inputs_for/1` to build forms. **Never** use `Phoenix.HTML.form_for` or `Phoenix.HTML.inputs_for` as they are outdated
+- When building forms **always** use `Phoenix.Component.to_form/2` (`assign(socket, form: to_form(...))` and `<.form for={@form} id="msg-form">`), then access fields via `@form[:field]`
+- **Always** add unique DOM IDs to key elements (forms, buttons, etc.)
+- For app-wide template imports, import/alias into `setlistify_web.ex`'s `html_helpers` block so they are available to all LiveViews and modules that `use SetlistifyWeb, :html`
+
+- Elixir supports `if/else` but **does NOT support `if/else if` or `if/elsif`**. **Always** use `cond` or `case` for multiple conditionals.
+
+  **Never do this (invalid)**:
+
+      <%= if condition do %>
+        ...
+      <% else if other_condition %>
+        ...
+      <% end %>
+
+  **Always** do this:
+
+      <%= cond do %>
+        <% condition -> %>
+          ...
+        <% other_condition -> %>
+          ...
+        <% true -> %>
+          ...
+      <% end %>
+
+- HEEx requires `phx-no-curly-interpolation` on parent tags when you need literal `{` or `}`:
+
+      <code phx-no-curly-interpolation>
+        let obj = {key: "val"}
+      </code>
+
+- HEEx class attrs support lists — **always** use `[...]` syntax for multiple class values:
+
+      <a class={[
+        "px-2 text-white",
+        @some_flag && "py-5",
+        if(@other_condition, do: "border-red-500", else: "border-blue-100"),
+      ]}>Text</a>
+
+- **Never** use `<% Enum.each %>` for generating template content, instead **always** use `<%= for item <- @collection do %>`
+- HEEx HTML comments use `<%!-- comment --%>`. **Always** use this syntax for template comments
+- **Always** use `{...}` for interpolation within tag attributes, and `<%= ... %>` for block constructs (if, cond, case, for) within tag bodies:
+
+  **Always** do this:
+
+      <div id={@id}>
+        {@my_assign}
+        <%= if @some_condition do %>
+          {@another_assign}
+        <% end %>
+      </div>
+
+  **Never** do this — the program will terminate with a syntax error:
+
+      <%!-- THIS IS INVALID NEVER EVER DO THIS --%>
+      <div id="<%= @invalid_interpolation %>">
+        {if @invalid_block_construct do}
+        {end}
+      </div>
+
+<!-- phoenix:html-end -->
+
+<!-- phoenix:liveview-start -->
+## Phoenix LiveView guidelines
+
+- **Never** use the deprecated `live_redirect` and `live_patch` functions, instead **always** use `<.link navigate={href}>` and `<.link patch={href}>` in templates, and `push_navigate` and `push_patch` in LiveViews
+- **Avoid LiveComponents** unless you have a strong, specific need for them
+- LiveViews should be named like `SetlistifyWeb.WeatherLive`, with a `Live` suffix
+
+### LiveView streams
+
+- **Always** use LiveView streams for collections to avoid memory ballooning:
+  - append — `stream(socket, :items, [new_item])`
+  - reset — `stream(socket, :items, new_items, reset: true)`
+  - prepend — `stream(socket, :items, [new_item], at: -1)`
+  - delete — `stream_delete(socket, :items, item)`
+
+- The template must set `phx-update="stream"` on the parent element and use the stream id as the child DOM id:
+
+      <div id="messages" phx-update="stream">
+        <div :for={{id, msg} <- @streams.messages} id={id}>
+          {msg.text}
+        </div>
+      </div>
+
+- Streams are *not* enumerable. To filter, refetch the data and re-stream with `reset: true`
+- Streams do not support counting or empty states natively — track counts with a separate assign
+- When an assign change should affect streamed item content, re-stream the affected items via `stream_insert`
+- **Never** use the deprecated `phx-update="append"` or `phx-update="prepend"`
+
+### LiveView JavaScript interop
+
+- Anytime you use `phx-hook="MyHook"` and that hook manages its own DOM, you **must** also set `phx-update="ignore"`
+- **Always** provide a unique DOM id alongside `phx-hook`
+
+<!-- phoenix:liveview-end -->
+
+<!-- usage-rules-end -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,102 @@
+# AGENTS.md
+
+This file provides guidance for AI coding assistants working with this repository.
+
+## Commands
+
+### Setup & Running
+
+```shell
+# Initialize the project (first time setup)
+bin/init
+
+# Run the Phoenix server with iex
+bin/server
+
+# Install dependencies
+mix deps.get
+
+# Compile the project
+mix compile
+
+# Run tests
+mix test
+
+# Run a specific test file
+mix test test/path/to/test_file.exs
+
+# Run a specific test (line number)
+mix test test/path/to/test_file.exs:123
+
+# Format code
+mix format
+
+# Static analysis with Dialyzer
+mix dialyzer
+```
+
+## Architecture
+
+Setlistify is an Elixir/Phoenix application that integrates with:
+1. Setlist.fm API - to fetch artist setlists
+2. Spotify API - to create playlists from setlists
+
+### Key Components
+
+#### Setlist.fm Integration
+- `Setlistify.SetlistFm.API` - Interface module with callbacks for searching and fetching setlists
+- `Setlistify.SetlistFm.API.ExternalClient` - Implementation of the API for actual HTTP requests
+
+#### Spotify Integration
+- `Setlistify.Spotify.API` - Interface for Spotify API operations (search tracks, create playlists)
+- `Setlistify.Spotify.API.ExternalClient` - Implementation for actual HTTP requests
+- `Setlistify.Spotify.SessionManager` - GenServer for managing user Spotify sessions (tokens)
+- `Setlistify.Spotify.SessionSupervisor` - Supervisor for session management processes
+
+#### Token Management
+- Each user has a separate token manager process identified by user ID
+- Tokens are automatically refreshed before they expire
+- Registry and DynamicSupervisor are used to track and manage token processes
+
+#### Web Interface
+- Phoenix LiveView for interactive UI components
+- Main paths:
+  - `/` - Search interface
+  - `/setlist/:id` - View specific setlist
+  - `/playlists` - View playlists
+
+#### Authentication
+- OAuth integration with Spotify
+- Token refreshing handled with GenServer processes
+
+### Testing
+
+The application uses Hammox for mocking:
+- `Setlistify.SetlistFm.API.MockClient` for setlist.fm API
+- `Setlistify.Spotify.API.MockClient` for Spotify API
+- Recommendation: use Hammox for mocks, not Mox. It has the same API as Mox.
+
+## Environment Configuration
+
+Required environment variables:
+- `SETLIST_FM_API_SECRET` - API key for Setlist.fm
+- `SPOTIFY_CLIENT_ID` - OAuth client ID for Spotify
+- `SPOTIFY_CLIENT_SECRET` - OAuth client secret for Spotify
+
+Optional environment variables for Grafana Cloud observability:
+- `GRAFANA_CLOUD_API_KEY` - API key for Grafana Cloud (shared for all services)
+- `GRAFANA_CLOUD_USER_ID` - User ID for Tempo from Grafana Cloud
+- `GRAFANA_CLOUD_TEMPO_ENDPOINT` - Tempo endpoint for traces
+- `GRAFANA_CLOUD_LOKI_ENDPOINT` - Loki endpoint for logs (must include /loki/api/v1/push)
+- `GRAFANA_CLOUD_LOKI_USER_ID` - User ID for Loki (usually different from Tempo)
+- `GRAFANA_CLOUD_REGION` - Cloud region (defaults to "us-central1")
+- `GRAFANA_CLOUD_ZONE` - Cloud zone (optional)
+
+These values are automatically loaded from `.env` in development. You can copy `.env.example` to `.env` and fill in the values.
+
+## Development Reminders
+
+- Run `mix format` after making changes (includes Styler auto-rewrites)
+- Run `mix credo --strict` to check for static analysis issues
+- Run `mix test` to run all tests
+- Run format frequently to avoid style warnings, especially before planning to commit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,32 +8,33 @@ This is a web application written using the Phoenix web framework.
 ### Phoenix v1.8 guidelines
 
 - **Always** begin your LiveView templates with `<Layouts.app flash={@flash} ...>` which wraps all inner content
-- The `SetlistifyWeb.Layouts` module is aliased in `setlistify_web.ex`, so you can use it without needing to alias it again
+- The `MyAppWeb.Layouts` module is aliased in the `my_app_web.ex` file, so you can use it without needing to alias it again
 - Anytime you run into errors with no `current_scope` assign:
   - You failed to follow the Authenticated Routes guidelines, or you failed to pass `current_scope` to `<Layouts.app>`
   - **Always** fix the `current_scope` error by moving your routes to the proper `live_session` and ensure you pass `current_scope` as needed
 - Phoenix v1.8 moved the `<.flash_group>` component to the `Layouts` module. You are **forbidden** from calling `<.flash_group>` outside of the `layouts.ex` module
-- Out of the box, `core_components.ex` imports an `<.icon name="hero-x-mark" class="w-5 h-5"/>` component for hero icons. **Always** use the `<.icon>` component for icons, **never** use `Heroicons` modules or similar
-- **Always** use the imported `<.input>` component for form inputs from `core_components.ex` when available
-- If you override the default input classes (`<.input class="myclass px-2 py-1 rounded-lg">`) with your own values, no default classes are inherited, so your custom classes must fully style the input
+- Out of the box, `core_components.ex` imports an `<.icon name="hero-x-mark" class="w-5 h-5"/>` component for for hero icons. **Always** use the `<.icon>` component for icons, **never** use `Heroicons` modules or similar
+- **Always** use the imported `<.input>` component for form inputs from `core_components.ex` when available. `<.input>` is imported and using it will will save steps and prevent errors
+- If you override the default input classes (`<.input class="myclass px-2 py-1 rounded-lg">)`) class with your own values, no default classes are inherited, so your
+custom classes must fully style the input
 
 ### JS and CSS guidelines
 
-- **Use Tailwind CSS classes and custom CSS rules** to create polished, responsive, and visually stunning interfaces
-- Tailwind CSS v4 **no longer needs a tailwind.config.js** and uses a new import syntax in `app.css`:
+- **Use Tailwind CSS classes and custom CSS rules** to create polished, responsive, and visually stunning interfaces.
+- Tailwindcss v4 **no longer needs a tailwind.config.js** and uses a new import syntax in `app.css`:
 
       @import "tailwindcss" source(none);
       @source "../css";
       @source "../js";
-      @source "../../lib/setlistify_web";
+      @source "../../lib/my_app_web";
 
 - **Always use and maintain this import syntax** in the app.css file for projects generated with `phx.new`
-- **Never** use `@apply` when writing raw CSS
-- **Always** manually write your own Tailwind-based components instead of using daisyUI for a unique, world-class design
+- **Never** use `@apply` when writing raw css
+- **Always** manually write your own tailwind-based components instead of using daisyUI for a unique, world-class design
 - Out of the box **only the app.js and app.css bundles are supported**
-  - You cannot reference an external vendored script `src` or link `href` in the layouts
-  - You must import vendor deps into app.js and app.css to use them
-  - **Never write inline `<script>custom js</script>` tags within templates**
+  - You cannot reference an external vendor'd script `src` or link `href` in the layouts
+  - You must import the vendor deps into app.js and app.css to use them
+  - **Never write inline <script>custom js</script> tags within templates**
 
 ### UI/UX & design guidelines
 
@@ -41,6 +42,7 @@ This is a web application written using the Phoenix web framework.
 - Implement **subtle micro-interactions** (e.g., button hover effects, and smooth transitions)
 - Ensure **clean typography, spacing, and layout balance** for a refined, premium look
 - Focus on **delightful details** like hover effects, loading states, and smooth page transitions
+
 
 <!-- usage-rules-start -->
 
@@ -55,14 +57,14 @@ This is a web application written using the Phoenix web framework.
       mylist = ["blue", "green"]
       mylist[i]
 
-  Instead, **always** use `Enum.at`, pattern matching, or `List` for index based list access:
+  Instead, **always** use `Enum.at`, pattern matching, or `List` for index based list access, ie:
 
       i = 0
       mylist = ["blue", "green"]
       Enum.at(mylist, i)
 
-- Elixir variables are immutable, but can be rebound, so for block expressions like `if`, `case`, `cond`, etc.
-  you *must* bind the result of the expression to a variable if you want to use it and you CANNOT rebind the result inside the expression:
+- Elixir variables are immutable, but can be rebound, so for block expressions like `if`, `case`, `cond`, etc
+  you *must* bind the result of the expression to a variable if you want to use it and you CANNOT rebind the result inside the expression, ie:
 
       # INVALID: we are rebinding inside the `if` and the result never gets assigned
       if connected?(socket) do
@@ -76,60 +78,59 @@ This is a web application written using the Phoenix web framework.
         end
 
 - **Never** nest multiple modules in the same file as it can cause cyclic dependencies and compilation errors
-- **Never** use map access syntax (`changeset[:field]`) on structs as they do not implement the Access behaviour by default. Access struct fields directly (`my_struct.field`) or use higher level APIs where available
-- Elixir's standard library has everything necessary for date and time manipulation. **Never** install additional dependencies unless asked or for date/time parsing (where you can use the `date_time_parser` package)
+- **Never** use map access syntax (`changeset[:field]`) on structs as they do not implement the Access behaviour by default. For regular structs, you **must** access the fields directly, such as `my_struct.field` or use higher level APIs that are available on the struct if they exist, `Ecto.Changeset.get_field/2` for changesets
+- Elixir's standard library has everything necessary for date and time manipulation. Familiarize yourself with the common `Time`, `Date`, `DateTime`, and `Calendar` interfaces by accessing their documentation as necessary. **Never** install additional dependencies unless asked or for date/time parsing (which you can use the `date_time_parser` package)
 - Don't use `String.to_atom/1` on user input (memory leak risk)
-- Predicate function names should not start with `is_` and should end in a question mark
-- Elixir's built-in OTP primitives like `DynamicSupervisor` and `Registry` require names in the child spec, such as `{DynamicSupervisor, name: Setlistify.MyDynamicSup}`, then `DynamicSupervisor.start_child(Setlistify.MyDynamicSup, child_spec)`
-- Use `Task.async_stream(collection, callback, options)` for concurrent enumeration with back-pressure. Usually pass `timeout: :infinity`
+- Predicate function names should not start with `is_` and should end in a question mark. Names like `is_thing` should be reserved for guards
+- Elixir's builtin OTP primitives like `DynamicSupervisor` and `Registry`, require names in the child spec, such as `{DynamicSupervisor, name: MyApp.MyDynamicSup}`, then you can use `DynamicSupervisor.start_child(MyApp.MyDynamicSup, child_spec)`
+- Use `Task.async_stream(collection, callback, options)` for concurrent enumeration with back-pressure. The majority of times you will want to pass `timeout: :infinity` as option
 
 ## Mix guidelines
 
-- Read the docs and options before using tasks (`mix help task_name`)
-- To debug test failures, run `mix test test/my_test.exs` or `mix test --failed`
+- Read the docs and options before using tasks (by using `mix help task_name`)
+- To debug test failures, run tests in a specific file with `mix test test/my_test.exs` or run all previously failed tests with `mix test --failed`
 - `mix deps.clean --all` is **almost never needed**. **Avoid** using it unless you have good reason
-
-## Test guidelines
-
-- **Always use `start_supervised!/1`** to start processes in tests as it guarantees cleanup between tests
-- **Avoid** `Process.sleep/1` and `Process.alive?/1` in tests
-  - Instead of sleeping to wait for a process to finish, **always** use `Process.monitor/1` and assert on the DOWN message:
-
-        ref = Process.monitor(pid)
-        assert_receive {:DOWN, ^ref, :process, ^pid, :normal}
-
-  - Instead of sleeping to synchronize before the next call, **always** use `_ = :sys.get_state/1` to ensure the process has handled prior messages
-
 <!-- phoenix:elixir-end -->
 
 <!-- phoenix:phoenix-start -->
 ## Phoenix guidelines
 
-- Remember Phoenix router `scope` blocks include an optional alias which is prefixed for all routes within the scope. **Always** be mindful of this to avoid duplicate module prefixes.
+- Remember Phoenix router `scope` blocks include an optional alias which is prefixed for all routes within the scope. **Always** be mindful of this when creating routes within a scope to avoid duplicate module prefixes.
 
-- You **never** need to create your own `alias` for route definitions — the `scope` provides the alias:
+- You **never** need to create your own `alias` for route definitions! The `scope` provides the alias, ie:
 
-      scope "/admin", SetlistifyWeb.Admin do
+      scope "/admin", AppWeb.Admin do
         pipe_through :browser
+
         live "/users", UserLive, :index
       end
 
-  the `UserLive` route points to `SetlistifyWeb.Admin.UserLive`
+  the UserLive route would point to the `AppWeb.Admin.UserLive` module
 
 - `Phoenix.View` no longer is needed or included with Phoenix, don't use it
-
 <!-- phoenix:phoenix-end -->
+
+<!-- phoenix:ecto-start -->
+## Ecto Guidelines
+
+- **Always** preload Ecto associations in queries when they'll be accessed in templates, ie a message that needs to reference the `message.user.email`
+- Remember `import Ecto.Query` and other supporting modules when you write `seeds.exs`
+- `Ecto.Schema` fields always use the `:string` type, even for `:text`, columns, ie: `field :name, :string`
+- `Ecto.Changeset.validate_number/2` **DOES NOT SUPPORT the `:allow_nil` option**. By default, Ecto validations only run if a change for the given field exists and the change value is not nil, so such as option is never needed
+- You **must** use `Ecto.Changeset.get_field(changeset, :field)` to access changeset fields
+- Fields which are set programatically, such as `user_id`, must not be listed in `cast` calls or similar for security purposes. Instead they must be explicitly set when creating the struct
+<!-- phoenix:ecto-end -->
 
 <!-- phoenix:html-start -->
 ## Phoenix HTML guidelines
 
-- Phoenix templates **always** use `~H` or `.html.heex` files (HEEx), **never** use `~E`
-- **Always** use `Phoenix.Component.form/1` and `Phoenix.Component.inputs_for/1` to build forms. **Never** use `Phoenix.HTML.form_for` or `Phoenix.HTML.inputs_for` as they are outdated
-- When building forms **always** use `Phoenix.Component.to_form/2` (`assign(socket, form: to_form(...))` and `<.form for={@form} id="msg-form">`), then access fields via `@form[:field]`
-- **Always** add unique DOM IDs to key elements (forms, buttons, etc.)
-- For app-wide template imports, import/alias into `setlistify_web.ex`'s `html_helpers` block so they are available to all LiveViews and modules that `use SetlistifyWeb, :html`
+- Phoenix templates **always** use `~H` or .html.heex files (known as HEEx), **never** use `~E`
+- **Always** use the imported `Phoenix.Component.form/1` and `Phoenix.Component.inputs_for/1` function to build forms. **Never** use `Phoenix.HTML.form_for` or `Phoenix.HTML.inputs_for` as they are outdated
+- When building forms **always** use the already imported `Phoenix.Component.to_form/2` (`assign(socket, form: to_form(...))` and `<.form for={@form} id="msg-form">`), then access those forms in the template via `@form[:field]`
+- **Always** add unique DOM IDs to key elements (like forms, buttons, etc) when writing templates, these IDs can later be used in tests (`<.form for={@form} id="product-form">`)
+- For "app wide" template imports, you can import/alias into the `my_app_web.ex`'s `html_helpers` block, so they will be available to all LiveViews, LiveComponent's, and all modules that do `use MyAppWeb, :html` (replace "my_app" by the actual app name)
 
-- Elixir supports `if/else` but **does NOT support `if/else if` or `if/elsif`**. **Always** use `cond` or `case` for multiple conditionals.
+- Elixir supports `if/else` but **does NOT support `if/else if` or `if/elsif`. **Never use `else if` or `elseif` in Elixir**, **always** use `cond` or `case` for multiple conditionals.
 
   **Never do this (invalid)**:
 
@@ -139,70 +140,84 @@ This is a web application written using the Phoenix web framework.
         ...
       <% end %>
 
-  **Always** do this:
+  Instead **always** do this:
 
       <%= cond do %>
         <% condition -> %>
           ...
-        <% other_condition -> %>
+        <% condition2 -> %>
           ...
         <% true -> %>
           ...
       <% end %>
 
-- HEEx requires `phx-no-curly-interpolation` on parent tags when you need literal `{` or `}`:
+- HEEx require special tag annotation if you want to insert literal curly's like `{` or `}`. If you want to show a textual code snippet on the page in a `<pre>` or `<code>` block you *must* annotate the parent tag with `phx-no-curly-interpolation`:
 
       <code phx-no-curly-interpolation>
         let obj = {key: "val"}
       </code>
 
-- HEEx class attrs support lists — **always** use `[...]` syntax for multiple class values:
+  Within `phx-no-curly-interpolation` annotated tags, you can use `{` and `}` without escaping them, and dynamic Elixir expressions can still be used with `<%= ... %>` syntax
+
+- HEEx class attrs support lists, but you must **always** use list `[...]` syntax. You can use the class list syntax to conditionally add classes, **always do this for multiple class values**:
 
       <a class={[
         "px-2 text-white",
         @some_flag && "py-5",
         if(@other_condition, do: "border-red-500", else: "border-blue-100"),
+        ...
       ]}>Text</a>
 
-- **Never** use `<% Enum.each %>` for generating template content, instead **always** use `<%= for item <- @collection do %>`
-- HEEx HTML comments use `<%!-- comment --%>`. **Always** use this syntax for template comments
-- **Always** use `{...}` for interpolation within tag attributes, and `<%= ... %>` for block constructs (if, cond, case, for) within tag bodies:
+  and **always** wrap `if`'s inside `{...}` expressions with parens, like done above (`if(@other_condition, do: "...", else: "...")`)
+
+  and **never** do this, since it's invalid (note the missing `[` and `]`):
+
+      <a class={
+        "px-2 text-white",
+        @some_flag && "py-5"
+      }> ...
+      => Raises compile syntax error on invalid HEEx attr syntax
+
+- **Never** use `<% Enum.each %>` or non-for comprehensions for generating template content, instead **always** use `<%= for item <- @collection do %>`
+- HEEx HTML comments use `<%!-- comment --%>`. **Always** use the HEEx HTML comment syntax for template comments (`<%!-- comment --%>`)
+- HEEx allows interpolation via `{...}` and `<%= ... %>`, but the `<%= %>` **only** works within tag bodies. **Always** use the `{...}` syntax for interpolation within tag attributes, and for interpolation of values within tag bodies. **Always** interpolate block constructs (if, cond, case, for) within tag bodies using `<%= ... %>`.
 
   **Always** do this:
 
       <div id={@id}>
         {@my_assign}
-        <%= if @some_condition do %>
+        <%= if @some_block_condition do %>
           {@another_assign}
         <% end %>
       </div>
 
-  **Never** do this — the program will terminate with a syntax error:
+  and **Never** do this – the program will terminate with a syntax error:
 
       <%!-- THIS IS INVALID NEVER EVER DO THIS --%>
       <div id="<%= @invalid_interpolation %>">
         {if @invalid_block_construct do}
         {end}
       </div>
-
 <!-- phoenix:html-end -->
 
 <!-- phoenix:liveview-start -->
 ## Phoenix LiveView guidelines
 
-- **Never** use the deprecated `live_redirect` and `live_patch` functions, instead **always** use `<.link navigate={href}>` and `<.link patch={href}>` in templates, and `push_navigate` and `push_patch` in LiveViews
-- **Avoid LiveComponents** unless you have a strong, specific need for them
-- LiveViews should be named like `SetlistifyWeb.WeatherLive`, with a `Live` suffix
+- **Never** use the deprecated `live_redirect` and `live_patch` functions, instead **always** use the `<.link navigate={href}>` and  `<.link patch={href}>` in templates, and `push_navigate` and `push_patch` functions LiveViews
+- **Avoid LiveComponent's** unless you have a strong, specific need for them
+- LiveViews should be named like `AppWeb.WeatherLive`, with a `Live` suffix. When you go to add LiveView routes to the router, the default `:browser` scope is **already aliased** with the `AppWeb` module, so you can just do `live "/weather", WeatherLive`
+- Remember anytime you use `phx-hook="MyHook"` and that js hook manages its own DOM, you **must** also set the `phx-update="ignore"` attribute
+- **Never** write embedded `<script>` tags in HEEx. Instead always write your scripts and hooks in the `assets/js` directory and integrate them with the `assets/js/app.js` file
 
 ### LiveView streams
 
-- **Always** use LiveView streams for collections to avoid memory ballooning:
-  - append — `stream(socket, :items, [new_item])`
-  - reset — `stream(socket, :items, new_items, reset: true)`
-  - prepend — `stream(socket, :items, [new_item], at: -1)`
-  - delete — `stream_delete(socket, :items, item)`
+- **Always** use LiveView streams for collections for assigning regular lists to avoid memory ballooning and runtime termination with the following operations:
+  - basic append of N items - `stream(socket, :messages, [new_msg])`
+  - resetting stream with new items - `stream(socket, :messages, [new_msg], reset: true)` (e.g. for filtering items)
+  - prepend to stream - `stream(socket, :messages, [new_msg], at: -1)`
+  - deleting items - `stream_delete(socket, :messages, msg)`
 
-- The template must set `phx-update="stream"` on the parent element and use the stream id as the child DOM id:
+- When using the `stream/3` interfaces in the LiveView, the LiveView template must 1) always set `phx-update="stream"` on the parent element, with a DOM id on the parent element like `id="messages"` and 2) consume the `@streams.stream_name` collection and use the id as the DOM id for each child. For a call like `stream(socket, :messages, [new_msg])` in the LiveView, the template would be:
 
       <div id="messages" phx-update="stream">
         <div :for={{id, msg} <- @streams.messages} id={id}>
@@ -210,16 +225,110 @@ This is a web application written using the Phoenix web framework.
         </div>
       </div>
 
-- Streams are *not* enumerable. To filter, refetch the data and re-stream with `reset: true`
-- Streams do not support counting or empty states natively — track counts with a separate assign
-- When an assign change should affect streamed item content, re-stream the affected items via `stream_insert`
-- **Never** use the deprecated `phx-update="append"` or `phx-update="prepend"`
+- LiveView streams are *not* enumerable, so you cannot use `Enum.filter/2` or `Enum.reject/2` on them. Instead, if you want to filter, prune, or refresh a list of items on the UI, you **must refetch the data and re-stream the entire stream collection, passing reset: true**:
 
-### LiveView JavaScript interop
+      def handle_event("filter", %{"filter" => filter}, socket) do
+        # re-fetch the messages based on the filter
+        messages = list_messages(filter)
 
-- Anytime you use `phx-hook="MyHook"` and that hook manages its own DOM, you **must** also set `phx-update="ignore"`
-- **Always** provide a unique DOM id alongside `phx-hook`
+        {:noreply,
+        socket
+        |> assign(:messages_empty?, messages == [])
+        # reset the stream with the new messages
+        |> stream(:messages, messages, reset: true)}
+      end
 
+- LiveView streams *do not support counting or empty states*. If you need to display a count, you must track it using a separate assign. For empty states, you can use Tailwind classes:
+
+      <div id="tasks" phx-update="stream">
+        <div class="hidden only:block">No tasks yet</div>
+        <div :for={{id, task} <- @stream.tasks} id={id}>
+          {task.name}
+        </div>
+      </div>
+
+  The above only works if the empty state is the only HTML block alongside the stream for-comprehension.
+
+- **Never** use the deprecated `phx-update="append"` or `phx-update="prepend"` for collections
+
+### LiveView tests
+
+- `Phoenix.LiveViewTest` module and `LazyHTML` (included) for making your assertions
+- Form tests are driven by `Phoenix.LiveViewTest`'s `render_submit/2` and `render_change/2` functions
+- Come up with a step-by-step test plan that splits major test cases into small, isolated files. You may start with simpler tests that verify content exists, gradually add interaction tests
+- **Always reference the key element IDs you added in the LiveView templates in your tests** for `Phoenix.LiveViewTest` functions like `element/2`, `has_element/2`, selectors, etc
+- **Never** tests again raw HTML, **always** use `element/2`, `has_element/2`, and similar: `assert has_element?(view, "#my-form")`
+- Instead of relying on testing text content, which can change, favor testing for the presence of key elements
+- Focus on testing outcomes rather than implementation details
+- Be aware that `Phoenix.Component` functions like `<.form>` might produce different HTML than expected. Test against the output HTML structure, not your mental model of what you expect it to be
+- When facing test failures with element selectors, add debug statements to print the actual HTML, but use `LazyHTML` selectors to limit the output, ie:
+
+      html = render(view)
+      document = LazyHTML.from_fragment(html)
+      matches = LazyHTML.filter(document, "your-complex-selector")
+      IO.inspect(matches, label: "Matches")
+
+### Form handling
+
+#### Creating a form from params
+
+If you want to create a form based on `handle_event` params:
+
+    def handle_event("submitted", params, socket) do
+      {:noreply, assign(socket, form: to_form(params))}
+    end
+
+When you pass a map to `to_form/1`, it assumes said map contains the form params, which are expected to have string keys.
+
+You can also specify a name to nest the params:
+
+    def handle_event("submitted", %{"user" => user_params}, socket) do
+      {:noreply, assign(socket, form: to_form(user_params, as: :user))}
+    end
+
+#### Creating a form from changesets
+
+When using changesets, the underlying data, form params, and errors are retrieved from it. The `:as` option is automatically computed too. E.g. if you have a user schema:
+
+    defmodule MyApp.Users.User do
+      use Ecto.Schema
+      ...
+    end
+
+And then you create a changeset that you pass to `to_form`:
+
+    %MyApp.Users.User{}
+    |> Ecto.Changeset.change()
+    |> to_form()
+
+Once the form is submitted, the params will be available under `%{"user" => user_params}`.
+
+In the template, the form form assign can be passed to the `<.form>` function component:
+
+    <.form for={@form} id="todo-form" phx-change="validate" phx-submit="save">
+      <.input field={@form[:field]} type="text" />
+    </.form>
+
+Always give the form an explicit, unique DOM ID, like `id="todo-form"`.
+
+#### Avoiding form errors
+
+**Always** use a form assigned via `to_form/2` in the LiveView, and the `<.input>` component in the template. In the template **always access forms this**:
+
+    <%!-- ALWAYS do this (valid) --%>
+    <.form for={@form} id="my-form">
+      <.input field={@form[:field]} type="text" />
+    </.form>
+
+And **never** do this:
+
+    <%!-- NEVER do this (invalid) --%>
+    <.form for={@changeset} id="my-form">
+      <.input field={@changeset[:field]} type="text" />
+    </.form>
+
+- You are FORBIDDEN from accessing the changeset in the template as it will cause errors
+- **Never** use `<.form let={f} ...>` in the template, instead **always use `<.form for={@form} ...>`**, then drive all form references from the form assign as in `@form[:field]`. The UI should **always** be driven by a `to_form/2` assigned in the LiveView module that is derived from a changeset
 <!-- phoenix:liveview-end -->
 
 <!-- usage-rules-end -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+@AGENTS.md
+
 ## Commands
 
 ### Setup & Running

--- a/mix.exs
+++ b/mix.exs
@@ -105,7 +105,8 @@ defmodule Setlistify.MixProject do
     [
       setup: ["deps.get", "assets.setup"],
       "assets.setup": ["tailwind.install --if-missing", "esbuild.install --if-missing"],
-      "assets.deploy": ["tailwind setlistify --minify", "esbuild default --minify", "phx.digest"]
+      "assets.deploy": ["tailwind setlistify --minify", "esbuild default --minify", "phx.digest"],
+      precommit: ["compile --warnings-as-errors", "deps.unlock --unused", "format", "credo --strict", "test"]
     ]
   end
 


### PR DESCRIPTION
Closes #121

## Summary
- Adds `AGENTS.md` based on `CLAUDE.md`, adapted for general AI coding assistants (Cursor, Zed Agent, GitHub Copilot, etc.)
- Removes Claude Code-specific content (Tidewave MCP section), keeping all project-relevant guidance: commands, architecture, testing patterns, environment config, dev reminders

## Test plan
- [ ] Verify `AGENTS.md` is accurate and complete against current `CLAUDE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)