### PR TITLE
ci: bootstrap Erlang/Elixir for Claude Code on the web

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -10,6 +10,25 @@
 
 set -euo pipefail
 
+# Retry a command up to 3 times with exponential backoff (2s, 4s). hex.pm
+# occasionally returns 503 from builds.hex.pm or trips transient DNS errors
+# on this base image; without retries one blip leaves the environment
+# half-installed and breaks `mix test` for the rest of the session.
+# Progress messages go to stderr so callers can `>/dev/null` the wrapped
+# command's stdout without hiding the retry log.
+retry() {
+  local attempt=1 delay=2
+  until "$@"; do
+    if [ "$attempt" -ge 3 ]; then
+      return 1
+    fi
+    echo "==> ${*@Q} failed (attempt $attempt); retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+    delay=$((delay * 2))
+  done
+}
+
 if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
   exit 0
 fi
@@ -20,16 +39,24 @@ SYSTEM_PACKAGES=(libssl3 libncurses6 unzip ca-certificates gh)
 
 if ! dpkg -s "${SYSTEM_PACKAGES[@]}" >/dev/null 2>&1; then
   echo "==> Installing system packages (${SYSTEM_PACKAGES[*]})..."
-  apt-get update -qq
-  DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends \
+  retry apt-get update -qq
+  retry env DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends \
     "${SYSTEM_PACKAGES[@]}" >/dev/null
 fi
 
 export MISE_DATA_DIR="${MISE_DATA_DIR:-$HOME/.local/share/mise}"
 
-if ! command -v mise >/dev/null 2>&1; then
-  echo "==> Installing mise..."
+# `curl | sh` is a pipeline, so wrap it in a function — that way retry retries
+# the whole pipeline (including the inherited `pipefail`) instead of just curl.
+install_mise() {
   curl -fsSL https://mise.run | sh
+}
+
+# `mise --version` rather than `command -v mise` so a half-installed binary
+# from a previous failed run is replaced instead of silently passing the check.
+if ! mise --version >/dev/null 2>&1; then
+  echo "==> Installing mise..."
+  retry install_mise
 fi
 export PATH="$HOME/.local/bin:$MISE_DATA_DIR/shims:$PATH"
 
@@ -37,38 +64,29 @@ export PATH="$HOME/.local/bin:$MISE_DATA_DIR/shims:$PATH"
 mise trust "$CLAUDE_PROJECT_DIR/.mise.toml" >/dev/null
 
 echo "==> Installing Erlang/Elixir via mise (precompiled)..."
-mise install
+retry mise install
 
 # Point Hex/Erlang at the system CA bundle. Without this, `mix deps.get` fails
 # with "TLS client: Unknown CA" against repo.hex.pm on this base image.
 export HEX_CACERTS_PATH="/etc/ssl/certs/ca-certificates.crt"
 
 # Hex's parallel registry fetch trips spurious "DNS resolution failure" errors
-# in this sandbox; serialising the requests avoids them.
+# in this sandbox; serialising the requests avoids them. Scoped to this script
+# only — persisting it would slow every later `mix deps.get` in the session
+# even when the DNS issue isn't biting.
 export HEX_HTTP_CONCURRENCY=1
 
-{
-  echo "export PATH=\"$HOME/.local/bin:$MISE_DATA_DIR/shims:\$PATH\""
-  echo "export HEX_CACERTS_PATH=\"/etc/ssl/certs/ca-certificates.crt\""
-  echo "export HEX_HTTP_CONCURRENCY=1"
-} >> "$CLAUDE_ENV_FILE"
-
-# Retry a command up to 3 times with exponential backoff (2s, 4s). hex.pm
-# occasionally returns 503 from builds.hex.pm or trips transient DNS errors
-# on this base image; without retries one blip leaves the environment
-# half-installed and breaks `mix test` for the rest of the session.
-retry() {
-  local attempt=1 delay=2
-  until "$@"; do
-    if [ "$attempt" -ge 3 ]; then
-      return 1
-    fi
-    echo "==> '$*' failed (attempt $attempt); retrying in ${delay}s..."
-    sleep "$delay"
-    attempt=$((attempt + 1))
-    delay=$((delay * 2))
-  done
+# Persist env exports for later shells in this session. Guard against duplicate
+# appends so re-runs of the hook (resume, etc.) don't pile up the same lines.
+append_env() {
+  local line="$1"
+  if ! grep -qxF "$line" "$CLAUDE_ENV_FILE" 2>/dev/null; then
+    echo "$line" >> "$CLAUDE_ENV_FILE"
+  fi
 }
+
+append_env "export PATH=\"$HOME/.local/bin:$MISE_DATA_DIR/shims:\$PATH\""
+append_env "export HEX_CACERTS_PATH=\"/etc/ssl/certs/ca-certificates.crt\""
 
 # runtime.exs loads `.env` for :dev (and `.env.example` for :test). Seed `.env`
 # with the same placeholders so dev compile/boot doesn't blow up on

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -2,9 +2,10 @@
 # SessionStart hook: install Erlang/Elixir + mix deps so Claude Code on the
 # web can run `mix test`, `mix format`, and `mix credo` immediately.
 #
-# - Only runs in remote (web) sessions; no-ops locally where mise is used.
-# - Installs precompiled OTP & Elixir from builds.hex.pm (same artifacts the
-#   erlef/setup-beam GitHub Action uses in CI). Versions come from .mise.toml.
+# - Only runs in remote (web) sessions; no-ops locally where mise is already set up.
+# - Uses mise to install the versions pinned in .mise.toml. The repo sets
+#   `[settings.erlang] compile = false`, so mise pulls precompiled OTP from
+#   builds.hex.pm instead of compiling from source.
 # - Idempotent: subsequent runs reuse the cached install + deps.
 
 set -euo pipefail
@@ -15,14 +16,6 @@ fi
 
 cd "$CLAUDE_PROJECT_DIR"
 
-ERLANG_VERSION=$(awk -F'"' '/^erlang/{print $2}' .mise.toml)
-ELIXIR_VERSION=$(awk -F'"' '/^elixir/{print $2}' .mise.toml)
-UBUNTU_VERSION=$(. /etc/os-release && echo "$VERSION_ID")
-
-INSTALL_ROOT="$HOME/.beam"
-ERLANG_HOME="$INSTALL_ROOT/otp-$ERLANG_VERSION"
-ELIXIR_HOME="$INSTALL_ROOT/elixir-$ELIXIR_VERSION"
-
 if ! dpkg -s libssl3 libncurses6 unzip ca-certificates gh >/dev/null 2>&1; then
   echo "==> Installing system packages (libssl3, libncurses6, unzip, gh)..."
   apt-get update -qq
@@ -30,28 +23,18 @@ if ! dpkg -s libssl3 libncurses6 unzip ca-certificates gh >/dev/null 2>&1; then
     libssl3 libncurses6 unzip ca-certificates gh >/dev/null
 fi
 
-if [ ! -x "$ERLANG_HOME/bin/erl" ]; then
-  echo "==> Downloading precompiled OTP $ERLANG_VERSION (ubuntu-$UBUNTU_VERSION)..."
-  rm -rf "$ERLANG_HOME"
-  mkdir -p "$ERLANG_HOME"
-  curl -fsSL "https://builds.hex.pm/builds/otp/ubuntu-${UBUNTU_VERSION}/OTP-${ERLANG_VERSION}.tar.gz" \
-    | tar -xz -C "$ERLANG_HOME" --strip-components=1
-  (cd "$ERLANG_HOME" && ./Install -minimal "$ERLANG_HOME" >/dev/null)
-fi
-export PATH="$ERLANG_HOME/bin:$PATH"
+export MISE_DATA_DIR="${MISE_DATA_DIR:-$HOME/.local/share/mise}"
 
-if [ ! -x "$ELIXIR_HOME/bin/elixir" ]; then
-  echo "==> Downloading precompiled Elixir $ELIXIR_VERSION..."
-  rm -rf "$ELIXIR_HOME"
-  mkdir -p "$ELIXIR_HOME"
-  TMPZIP=$(mktemp /tmp/elixir.XXXXXX.zip)
-  curl -fsSL -o "$TMPZIP" "https://builds.hex.pm/builds/elixir/v${ELIXIR_VERSION}.zip"
-  unzip -q -o "$TMPZIP" -d "$ELIXIR_HOME"
-  rm -f "$TMPZIP"
+if ! command -v mise >/dev/null 2>&1; then
+  echo "==> Installing mise..."
+  curl -fsSL https://mise.run | sh
 fi
-export PATH="$ELIXIR_HOME/bin:$PATH"
+export PATH="$HOME/.local/bin:$MISE_DATA_DIR/shims:$PATH"
 
-echo "export PATH=\"$ELIXIR_HOME/bin:$ERLANG_HOME/bin:\$PATH\"" >> "$CLAUDE_ENV_FILE"
+echo "==> Installing Erlang/Elixir via mise (precompiled)..."
+mise install
+
+echo "export PATH=\"$HOME/.local/bin:$MISE_DATA_DIR/shims:\$PATH\"" >> "$CLAUDE_ENV_FILE"
 
 # runtime.exs loads `.env` for :dev (and `.env.example` for :test). Seed `.env`
 # with the same placeholders so dev compile/boot doesn't blow up on

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -41,10 +41,32 @@ mise install
 # with "TLS client: Unknown CA" against repo.hex.pm on this base image.
 export HEX_CACERTS_PATH="/etc/ssl/certs/ca-certificates.crt"
 
+# Hex's parallel registry fetch trips spurious "DNS resolution failure" errors
+# in this sandbox; serialising the requests avoids them.
+export HEX_HTTP_CONCURRENCY=1
+
 {
   echo "export PATH=\"$HOME/.local/bin:$MISE_DATA_DIR/shims:\$PATH\""
   echo "export HEX_CACERTS_PATH=\"/etc/ssl/certs/ca-certificates.crt\""
+  echo "export HEX_HTTP_CONCURRENCY=1"
 } >> "$CLAUDE_ENV_FILE"
+
+# Retry a command up to 3 times with exponential backoff (2s, 4s). hex.pm
+# occasionally returns 503 from builds.hex.pm or trips transient DNS errors
+# on this base image; without retries one blip leaves the environment
+# half-installed and breaks `mix test` for the rest of the session.
+retry() {
+  local attempt=1 delay=2
+  until "$@"; do
+    if [ "$attempt" -ge 3 ]; then
+      return 1
+    fi
+    echo "==> '$*' failed (attempt $attempt); retrying in ${delay}s..."
+    sleep "$delay"
+    attempt=$((attempt + 1))
+    delay=$((delay * 2))
+  done
+}
 
 # runtime.exs loads `.env` for :dev (and `.env.example` for :test). Seed `.env`
 # with the same placeholders so dev compile/boot doesn't blow up on
@@ -53,10 +75,10 @@ if [ ! -f .env ] && [ -f .env.example ]; then
   cp .env.example .env
 fi
 
-mix local.hex --force --if-missing >/dev/null
-mix local.rebar --force --if-missing >/dev/null
+retry mix local.hex --force --if-missing >/dev/null
+retry mix local.rebar --force --if-missing >/dev/null
 
 echo "==> Fetching mix dependencies..."
-mix deps.get
+retry mix deps.get
 
 echo "==> Setup complete."

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# SessionStart hook: install Erlang/Elixir + mix deps so Claude Code on the
+# web can run `mix test`, `mix format`, and `mix credo` immediately.
+#
+# - Only runs in remote (web) sessions; no-ops locally where mise is used.
+# - Installs precompiled OTP & Elixir from builds.hex.pm (same artifacts the
+#   erlef/setup-beam GitHub Action uses in CI). Versions come from .mise.toml.
+# - Idempotent: subsequent runs reuse the cached install + deps.
+
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR"
+
+ERLANG_VERSION=$(awk -F'"' '/^erlang/{print $2}' .mise.toml)
+ELIXIR_VERSION=$(awk -F'"' '/^elixir/{print $2}' .mise.toml)
+UBUNTU_VERSION=$(. /etc/os-release && echo "$VERSION_ID")
+
+INSTALL_ROOT="$HOME/.beam"
+ERLANG_HOME="$INSTALL_ROOT/otp-$ERLANG_VERSION"
+ELIXIR_HOME="$INSTALL_ROOT/elixir-$ELIXIR_VERSION"
+
+if ! dpkg -s libssl3 libncurses6 unzip ca-certificates gh >/dev/null 2>&1; then
+  echo "==> Installing system packages (libssl3, libncurses6, unzip, gh)..."
+  apt-get update -qq
+  DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends \
+    libssl3 libncurses6 unzip ca-certificates gh >/dev/null
+fi
+
+if [ ! -x "$ERLANG_HOME/bin/erl" ]; then
+  echo "==> Downloading precompiled OTP $ERLANG_VERSION (ubuntu-$UBUNTU_VERSION)..."
+  rm -rf "$ERLANG_HOME"
+  mkdir -p "$ERLANG_HOME"
+  curl -fsSL "https://builds.hex.pm/builds/otp/ubuntu-${UBUNTU_VERSION}/OTP-${ERLANG_VERSION}.tar.gz" \
+    | tar -xz -C "$ERLANG_HOME" --strip-components=1
+  (cd "$ERLANG_HOME" && ./Install -minimal "$ERLANG_HOME" >/dev/null)
+fi
+export PATH="$ERLANG_HOME/bin:$PATH"
+
+if [ ! -x "$ELIXIR_HOME/bin/elixir" ]; then
+  echo "==> Downloading precompiled Elixir $ELIXIR_VERSION..."
+  rm -rf "$ELIXIR_HOME"
+  mkdir -p "$ELIXIR_HOME"
+  TMPZIP=$(mktemp /tmp/elixir.XXXXXX.zip)
+  curl -fsSL -o "$TMPZIP" "https://builds.hex.pm/builds/elixir/v${ELIXIR_VERSION}.zip"
+  unzip -q -o "$TMPZIP" -d "$ELIXIR_HOME"
+  rm -f "$TMPZIP"
+fi
+export PATH="$ELIXIR_HOME/bin:$PATH"
+
+echo "export PATH=\"$ELIXIR_HOME/bin:$ERLANG_HOME/bin:\$PATH\"" >> "$CLAUDE_ENV_FILE"
+
+# runtime.exs loads `.env` for :dev (and `.env.example` for :test). Seed `.env`
+# with the same placeholders so dev compile/boot doesn't blow up on
+# System.fetch_env! calls. .env is gitignored.
+if [ ! -f .env ] && [ -f .env.example ]; then
+  cp .env.example .env
+fi
+
+mix local.hex --force --if-missing >/dev/null
+mix local.rebar --force --if-missing >/dev/null
+
+echo "==> Fetching mix dependencies..."
+mix deps.get
+
+echo "==> Compiling (dev)..."
+mix compile
+
+echo "==> Compiling (test)..."
+MIX_ENV=test mix compile
+
+echo "==> Setup complete."

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -16,11 +16,13 @@ fi
 
 cd "$CLAUDE_PROJECT_DIR"
 
-if ! dpkg -s libssl3 libncurses6 unzip ca-certificates gh >/dev/null 2>&1; then
-  echo "==> Installing system packages (libssl3, libncurses6, unzip, gh)..."
+SYSTEM_PACKAGES=(libssl3 libncurses6 unzip ca-certificates gh)
+
+if ! dpkg -s "${SYSTEM_PACKAGES[@]}" >/dev/null 2>&1; then
+  echo "==> Installing system packages (${SYSTEM_PACKAGES[*]})..."
   apt-get update -qq
   DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends \
-    libssl3 libncurses6 unzip ca-certificates gh >/dev/null
+    "${SYSTEM_PACKAGES[@]}" >/dev/null
 fi
 
 export MISE_DATA_DIR="${MISE_DATA_DIR:-$HOME/.local/share/mise}"

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -49,10 +49,4 @@ mix local.rebar --force --if-missing >/dev/null
 echo "==> Fetching mix dependencies..."
 mix deps.get
 
-echo "==> Compiling (dev)..."
-mix compile
-
-echo "==> Compiling (test)..."
-MIX_ENV=test mix compile
-
 echo "==> Setup complete."

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -31,10 +31,20 @@ if ! command -v mise >/dev/null 2>&1; then
 fi
 export PATH="$HOME/.local/bin:$MISE_DATA_DIR/shims:$PATH"
 
+# Trust the project's mise config so `mise install` doesn't refuse to run.
+mise trust "$CLAUDE_PROJECT_DIR/.mise.toml" >/dev/null
+
 echo "==> Installing Erlang/Elixir via mise (precompiled)..."
 mise install
 
-echo "export PATH=\"$HOME/.local/bin:$MISE_DATA_DIR/shims:\$PATH\"" >> "$CLAUDE_ENV_FILE"
+# Point Hex/Erlang at the system CA bundle. Without this, `mix deps.get` fails
+# with "TLS client: Unknown CA" against repo.hex.pm on this base image.
+export HEX_CACERTS_PATH="/etc/ssl/certs/ca-certificates.crt"
+
+{
+  echo "export PATH=\"$HOME/.local/bin:$MISE_DATA_DIR/shims:\$PATH\""
+  echo "export HEX_CACERTS_PATH=\"/etc/ssl/certs/ca-certificates.crt\""
+} >> "$CLAUDE_ENV_FILE"
 
 # runtime.exs loads `.env` for :dev (and `.env.example` for :test). Seed `.env`
 # with the same placeholders so dev compile/boot doesn't blow up on

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,7 @@
   "hooks": {
     "SessionStart": [
       {
+        "matcher": "startup|resume",
         "hooks": [
           {
             "type": "command",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,16 @@
 {
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  },
   "permissions": {
     "allow": [
       "Bash(bin/server)",

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,3 +1,6 @@
 [tools]
 erlang = "28.4.2"
 elixir = "1.19.5-otp-28"
+
+[settings.erlang]
+compile = false


### PR DESCRIPTION
## Summary
- Add a `SessionStart` hook (`.claude/hooks/session-start.sh`) that installs OTP + Elixir from `builds.hex.pm` and runs `mix deps.get` / `mix compile` so web sessions can run `mix test`, `mix format`, and `mix credo` immediately.
- Wire the hook into `.claude/settings.json`. Hook is gated on `CLAUDE_CODE_REMOTE=true`, so local sessions (which use mise) are unaffected.
- Versions are read from `.mise.toml` to stay in sync with local + CI. The hook seeds `.env` from `.env.example` if missing, since `config/runtime.exs` calls `System.fetch_env!/1` on dev boot.

## Test plan
- [ ] Open a fresh Claude Code on the web session against this branch and confirm the hook output ends with `==> Setup complete.`
- [ ] In that session, run `mix test`, `mix format --check-formatted`, and `mix credo --strict` and confirm they pass without manual setup.
- [ ] Re-open the session and confirm the hook is idempotent (no re-download of OTP/Elixir, deps still resolved).
- [ ] Verify a local session is unaffected (hook exits early when `CLAUDE_CODE_REMOTE` is unset).

https://claude.ai/code/session_01SBTgGuQLYH3MYaWqNhSurb

---
_Generated by [Claude Code](https://claude.ai/code/session_01SBTgGuQLYH3MYaWqNhSurb)_