### PR TITLE
ci: fix SessionStart hook so mix test works on Claude Code for the web

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -41,10 +41,32 @@ mise install
 # with "TLS client: Unknown CA" against repo.hex.pm on this base image.
 export HEX_CACERTS_PATH="/etc/ssl/certs/ca-certificates.crt"
 
+# Hex's parallel registry fetch trips spurious "DNS resolution failure" errors
+# in this sandbox; serialising the requests avoids them.
+export HEX_HTTP_CONCURRENCY=1
+
 {
   echo "export PATH=\"$HOME/.local/bin:$MISE_DATA_DIR/shims:\$PATH\""
   echo "export HEX_CACERTS_PATH=\"/etc/ssl/certs/ca-certificates.crt\""
+  echo "export HEX_HTTP_CONCURRENCY=1"
 } >> "$CLAUDE_ENV_FILE"
+
+# Retry a command up to 3 times with exponential backoff (2s, 4s). hex.pm
+# occasionally returns 503 from builds.hex.pm or trips transient DNS errors
+# on this base image; without retries one blip leaves the environment
+# half-installed and breaks `mix test` for the rest of the session.
+retry() {
+  local attempt=1 delay=2
+  until "$@"; do
+    if [ "$attempt" -ge 3 ]; then
+      return 1
+    fi
+    echo "==> '$*' failed (attempt $attempt); retrying in ${delay}s..."
+    sleep "$delay"
+    attempt=$((attempt + 1))
+    delay=$((delay * 2))
+  done
+}
 
 # runtime.exs loads `.env` for :dev (and `.env.example` for :test). Seed `.env`
 # with the same placeholders so dev compile/boot doesn't blow up on
@@ -53,10 +75,10 @@ if [ ! -f .env ] && [ -f .env.example ]; then
   cp .env.example .env
 fi
 
-mix local.hex --force --if-missing >/dev/null
-mix local.rebar --force --if-missing >/dev/null
+retry mix local.hex --force --if-missing >/dev/null
+retry mix local.rebar --force --if-missing >/dev/null
 
 echo "==> Fetching mix dependencies..."
-mix deps.get
+retry mix deps.get
 
 echo "==> Setup complete."

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -31,10 +31,20 @@ if ! command -v mise >/dev/null 2>&1; then
 fi
 export PATH="$HOME/.local/bin:$MISE_DATA_DIR/shims:$PATH"
 
+# Trust the project's mise config so `mise install` doesn't refuse to run.
+mise trust "$CLAUDE_PROJECT_DIR/.mise.toml" >/dev/null
+
 echo "==> Installing Erlang/Elixir via mise (precompiled)..."
 mise install
 
-echo "export PATH=\"$HOME/.local/bin:$MISE_DATA_DIR/shims:\$PATH\"" >> "$CLAUDE_ENV_FILE"
+# Point Hex/Erlang at the system CA bundle. Without this, `mix deps.get` fails
+# with "TLS client: Unknown CA" against repo.hex.pm on this base image.
+export HEX_CACERTS_PATH="/etc/ssl/certs/ca-certificates.crt"
+
+{
+  echo "export PATH=\"$HOME/.local/bin:$MISE_DATA_DIR/shims:\$PATH\""
+  echo "export HEX_CACERTS_PATH=\"/etc/ssl/certs/ca-certificates.crt\""
+} >> "$CLAUDE_ENV_FILE"
 
 # runtime.exs loads `.env` for :dev (and `.env.example` for :test). Seed `.env`
 # with the same placeholders so dev compile/boot doesn't blow up on


### PR DESCRIPTION
## Summary

Validated the SessionStart hook end-to-end by booting a fresh web session and running `mix test`. Hit two blockers; both are fixed here.

- `mise install` aborted on the project's `.mise.toml` with "Config files ... are not trusted." The hook now runs `mise trust "$CLAUDE_PROJECT_DIR/.mise.toml"` after installing mise.
- `mix deps.get` failed with `TLS client: Unknown CA` against `repo.hex.pm`. Erlang's `public_key:cacerts_get/0` returns 150 OS certs on this image, but Hex 2.4.2 doesn't pick them up automatically. Setting `HEX_CACERTS_PATH=/etc/ssl/certs/ca-certificates.crt` fixes it. The hook now exports it for the current run and writes it to `$CLAUDE_ENV_FILE` so subsequent commands inherit it.

After both fixes, `mix test` runs cleanly: **254 tests, 0 failures**.

## Test plan

- [x] Removed cached state and re-ran the hook via `CLAUDE_CODE_REMOTE=true ... bash .claude/hooks/session-start.sh` — completes with "Setup complete."
- [x] `mix test` passes (254 tests, 1 doctest, 0 failures).
- [ ] Verify on a brand-new web session that no manual intervention is needed before `mix test`.

https://claude.ai/code/session_01PBpkDjbhckJccyvq4e8d84

---
_Generated by [Claude Code](https://claude.ai/code/session_01PBpkDjbhckJccyvq4e8d84)_