### PR TITLE
ci: harden SessionStart hook against transient hex.pm failures

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -41,10 +41,32 @@ mise install
 # with "TLS client: Unknown CA" against repo.hex.pm on this base image.
 export HEX_CACERTS_PATH="/etc/ssl/certs/ca-certificates.crt"
 
+# Hex's parallel registry fetch trips spurious "DNS resolution failure" errors
+# in this sandbox; serialising the requests avoids them.
+export HEX_HTTP_CONCURRENCY=1
+
 {
   echo "export PATH=\"$HOME/.local/bin:$MISE_DATA_DIR/shims:\$PATH\""
   echo "export HEX_CACERTS_PATH=\"/etc/ssl/certs/ca-certificates.crt\""
+  echo "export HEX_HTTP_CONCURRENCY=1"
 } >> "$CLAUDE_ENV_FILE"
+
+# Retry a command up to 3 times with exponential backoff (2s, 4s). hex.pm
+# occasionally returns 503 from builds.hex.pm or trips transient DNS errors
+# on this base image; without retries one blip leaves the environment
+# half-installed and breaks `mix test` for the rest of the session.
+retry() {
+  local attempt=1 delay=2
+  until "$@"; do
+    if [ "$attempt" -ge 3 ]; then
+      return 1
+    fi
+    echo "==> '$*' failed (attempt $attempt); retrying in ${delay}s..."
+    sleep "$delay"
+    attempt=$((attempt + 1))
+    delay=$((delay * 2))
+  done
+}
 
 # runtime.exs loads `.env` for :dev (and `.env.example` for :test). Seed `.env`
 # with the same placeholders so dev compile/boot doesn't blow up on
@@ -53,10 +75,10 @@ if [ ! -f .env ] && [ -f .env.example ]; then
   cp .env.example .env
 fi
 
-mix local.hex --force --if-missing >/dev/null
-mix local.rebar --force --if-missing >/dev/null
+retry mix local.hex --force --if-missing >/dev/null
+retry mix local.rebar --force --if-missing >/dev/null
 
 echo "==> Fetching mix dependencies..."
-mix deps.get
+retry mix deps.get
 
 echo "==> Setup complete."


### PR DESCRIPTION
## Summary

While validating the web setup scripts, the SessionStart hook left the environment half-installed: `mise`/Erlang/Elixir were present, but Hex, rebar, and `deps/` were not, so `mix test` failed for the rest of the session.

Two root causes, both transient:

1. `builds.hex.pm` returned a 503 during `mix local.rebar`. With `set -euo pipefail`, that one failure aborts the hook before `mix deps.get` runs.
2. Hex's parallel registry fetch reports spurious `DNS resolution failure` errors in this sandbox (the system resolver and `inet_res:gethostbyname/1` both work fine for the same hosts). Capping `HEX_HTTP_CONCURRENCY=1` makes `mix deps.get` succeed reliably.

Changes in `.claude/hooks/session-start.sh`:
- Export `HEX_HTTP_CONCURRENCY=1` for the current run and persist it via `CLAUDE_ENV_FILE`.
- Add a small `retry` helper (3 attempts, 2s → 4s backoff) and wrap `mix local.hex`, `mix local.rebar`, and `mix deps.get` with it.

## Test plan

- [x] Re-ran the hook end-to-end; completes with `==> Setup complete.`
- [x] `mix test` → 1 doctest, 254 tests, 0 failures
- [ ] Validate on a fresh web session start

---
_Generated by [Claude Code](https://claude.ai/code/session_011d2RAnmgjjrJmu1hpKgUSF)_