### PR TITLE
fix: use cover artist when performing artist search misses

### DIFF
--- a/lib/setlistify/apple_music/api.ex
+++ b/lib/setlistify/apple_music/api.ex
@@ -14,12 +14,14 @@ defmodule Setlistify.AppleMusic.API do
     {:ok, %UserSession{user_token: user_token, storefront: storefront, user_id: user_id}}
   end
 
-  @callback search_for_track(UserSession.t(), String.t(), String.t()) ::
+  @callback search_for_track(UserSession.t(), String.t(), String.t(), String.t() | nil) ::
               nil | %{track_id: String.t()} | {:error, atom()}
-  def search_for_track(user_session, artist, track) do
-    Setlistify.Cache.fetch(:apple_music_track_cache, {artist, track}, fn {artist, track} ->
-      impl().search_for_track(user_session, artist, track)
-    end)
+  def search_for_track(user_session, artist, track, cover_artist \\ nil) do
+    Setlistify.Cache.fetch(
+      :apple_music_track_cache,
+      {artist, track, cover_artist},
+      fn _ -> impl().search_for_track(user_session, artist, track, cover_artist) end
+    )
   end
 
   @callback create_playlist(UserSession.t(), String.t(), String.t()) ::

--- a/lib/setlistify/apple_music/api/external_client.ex
+++ b/lib/setlistify/apple_music/api/external_client.ex
@@ -118,6 +118,8 @@ defmodule Setlistify.AppleMusic.API.ExternalClient do
 
   defp evaluate_search_result(nil, artist, track) do
     Logger.warning("No search results", %{artist: artist, track: track})
+
+    OpenTelemetry.Tracer.set_attributes([{"search.outcome", "no_results"}])
     {:ok, :no_match}
   end
 
@@ -125,7 +127,11 @@ defmodule Setlistify.AppleMusic.API.ExternalClient do
     result_artist = get_in(song, ["attributes", "artistName"])
 
     if artist_match?(artist, result_artist) do
-      OpenTelemetry.Tracer.set_attributes([{"track.id", song["id"]}])
+      OpenTelemetry.Tracer.set_attributes([
+        {"track.id", song["id"]},
+        {"search.outcome", "match"}
+      ])
+
       {:ok, %{track_id: song["id"]}}
     else
       Logger.warning("Rejected search result: artist mismatch", %{
@@ -133,6 +139,15 @@ defmodule Setlistify.AppleMusic.API.ExternalClient do
         returned_artist: result_artist,
         track: track
       })
+
+      OpenTelemetry.Tracer.set_attributes([{"search.outcome", "rejected_artist_mismatch"}])
+
+      OpenTelemetry.Tracer.add_event("search.result_rejected", [
+        {"reason", "artist_mismatch"},
+        {"queried_artist", artist},
+        {"returned_artist", result_artist || ""},
+        {"track", track}
+      ])
 
       {:ok, :no_match}
     end

--- a/lib/setlistify/apple_music/api/external_client.ex
+++ b/lib/setlistify/apple_music/api/external_client.ex
@@ -62,45 +62,26 @@ defmodule Setlistify.AppleMusic.API.ExternalClient do
     {:ok, %UserSession{user_token: user_token, storefront: storefront, user_id: user_id}}
   end
 
-  def search_for_track(user_session, artist, track) do
+  def search_for_track(user_session, artist, track, cover_artist \\ nil) do
     OpenTelemetry.Tracer.with_span "Setlistify.AppleMusic.API.ExternalClient.search_for_track" do
-      request_fn = fn req ->
-        Req.get(req,
-          url: "/v1/catalog/#{user_session.storefront}/search",
-          params: %{term: "#{artist} #{track}", types: "songs", limit: 1}
-        )
-      end
+      case do_search_for_track(user_session, artist, track) do
+        {:ok, %{track_id: _} = result} ->
+          result
 
-      case with_developer_token_refresh(user_session, request_fn, "track search") do
-        {:ok, %{status: 200} = resp} ->
-          songs =
-            resp.body |> Map.get("results", %{}) |> Map.get("songs", %{}) |> Map.get("data", [])
+        {:ok, :no_match} when is_binary(cover_artist) ->
+          OpenTelemetry.Tracer.set_attributes([{"search.fallback", "cover_artist"}])
 
-          case List.first(songs) do
-            nil ->
-              Logger.warning("No search results", %{artist: artist, track: track})
-              OpenTelemetry.Tracer.set_attributes([{"results.count", 0}])
-              OpenTelemetry.Tracer.set_status(:ok, "")
-              nil
-
-            song ->
-              OpenTelemetry.Tracer.set_attributes([
-                {"results.count", length(songs)},
-                {"track.id", song["id"]}
-              ])
-
-              OpenTelemetry.Tracer.set_status(:ok, "")
-              %{track_id: song["id"]}
+          case do_search_for_track(user_session, cover_artist, track) do
+            {:ok, %{track_id: _} = result} -> result
+            {:ok, :no_match} -> nil
+            {:error, _} = error -> error
           end
 
-        {:error, reason} = error ->
-          OpenTelemetry.Tracer.set_status(:error, inspect(reason))
-          error
-
-        {:ok, response} ->
-          Logger.error("Unexpected response from Apple Music search: #{inspect(response)}")
-          OpenTelemetry.Tracer.set_status(:error, "Unexpected response")
+        {:ok, :no_match} ->
           nil
+
+        {:error, _} = error ->
+          error
       end
     end
   rescue
@@ -109,6 +90,70 @@ defmodule Setlistify.AppleMusic.API.ExternalClient do
       OpenTelemetry.Tracer.record_exception(error)
       OpenTelemetry.Tracer.set_status(:error, "Exception: #{Exception.message(error)}")
       nil
+  end
+
+  defp do_search_for_track(user_session, artist, track) do
+    request_fn = fn req ->
+      Req.get(req,
+        url: "/v1/catalog/#{user_session.storefront}/search",
+        params: %{term: "#{artist} #{track}", types: "songs", limit: 1}
+      )
+    end
+
+    case with_developer_token_refresh(user_session, request_fn, "track search") do
+      {:ok, %{status: 200} = resp} ->
+        songs =
+          resp.body |> Map.get("results", %{}) |> Map.get("songs", %{}) |> Map.get("data", [])
+
+        case List.first(songs) do
+          nil ->
+            Logger.warning("No search results", %{artist: artist, track: track})
+            {:ok, :no_match}
+
+          song ->
+            result_artist = get_in(song, ["attributes", "artistName"])
+
+            if artist_match?(artist, result_artist) do
+              OpenTelemetry.Tracer.set_attributes([
+                {"results.count", length(songs)},
+                {"track.id", song["id"]}
+              ])
+
+              {:ok, %{track_id: song["id"]}}
+            else
+              Logger.warning("Rejected search result: artist mismatch", %{
+                queried_artist: artist,
+                returned_artist: result_artist,
+                track: track
+              })
+
+              {:ok, :no_match}
+            end
+        end
+
+      {:error, _} = error ->
+        error
+
+      {:ok, response} ->
+        Logger.error("Unexpected response from Apple Music search: #{inspect(response)}")
+        {:error, :unexpected_response}
+    end
+  end
+
+  defp artist_match?(_queried, nil), do: false
+
+  defp artist_match?(queried, returned) do
+    q = normalize_artist(queried)
+    r = normalize_artist(returned)
+    q != "" and r != "" and (String.contains?(r, q) or String.contains?(q, r))
+  end
+
+  defp normalize_artist(name) do
+    name
+    |> String.downcase()
+    |> String.replace(~r/[^\p{L}\p{N}\s]/u, " ")
+    |> String.replace(~r/\s+/u, " ")
+    |> String.trim()
   end
 
   def create_playlist(user_session, name, description) do

--- a/lib/setlistify/apple_music/api/external_client.ex
+++ b/lib/setlistify/apple_music/api/external_client.ex
@@ -105,31 +105,7 @@ defmodule Setlistify.AppleMusic.API.ExternalClient do
         songs =
           resp.body |> Map.get("results", %{}) |> Map.get("songs", %{}) |> Map.get("data", [])
 
-        case List.first(songs) do
-          nil ->
-            Logger.warning("No search results", %{artist: artist, track: track})
-            {:ok, :no_match}
-
-          song ->
-            result_artist = get_in(song, ["attributes", "artistName"])
-
-            if artist_match?(artist, result_artist) do
-              OpenTelemetry.Tracer.set_attributes([
-                {"results.count", length(songs)},
-                {"track.id", song["id"]}
-              ])
-
-              {:ok, %{track_id: song["id"]}}
-            else
-              Logger.warning("Rejected search result: artist mismatch", %{
-                queried_artist: artist,
-                returned_artist: result_artist,
-                track: track
-              })
-
-              {:ok, :no_match}
-            end
-        end
+        evaluate_search_result(List.first(songs), artist, track)
 
       {:error, _} = error ->
         error
@@ -140,21 +116,35 @@ defmodule Setlistify.AppleMusic.API.ExternalClient do
     end
   end
 
+  defp evaluate_search_result(nil, artist, track) do
+    Logger.warning("No search results", %{artist: artist, track: track})
+    {:ok, :no_match}
+  end
+
+  defp evaluate_search_result(song, artist, track) do
+    result_artist = get_in(song, ["attributes", "artistName"])
+
+    if artist_match?(artist, result_artist) do
+      OpenTelemetry.Tracer.set_attributes([{"track.id", song["id"]}])
+      {:ok, %{track_id: song["id"]}}
+    else
+      Logger.warning("Rejected search result: artist mismatch", %{
+        queried_artist: artist,
+        returned_artist: result_artist,
+        track: track
+      })
+
+      {:ok, :no_match}
+    end
+  end
+
   defp artist_match?(_queried, nil), do: false
 
   defp artist_match?(queried, returned) do
-    q = normalize_artist(queried)
-    r = normalize_artist(returned)
-    q != "" and r != "" and (String.contains?(r, q) or String.contains?(q, r))
+    String.equivalent?(normalize_artist(queried), normalize_artist(returned))
   end
 
-  defp normalize_artist(name) do
-    name
-    |> String.downcase()
-    |> String.replace(~r/[^\p{L}\p{N}\s]/u, " ")
-    |> String.replace(~r/\s+/u, " ")
-    |> String.trim()
-  end
+  defp normalize_artist(name), do: name |> String.downcase() |> String.trim()
 
   def create_playlist(user_session, name, description) do
     OpenTelemetry.Tracer.with_span "Setlistify.AppleMusic.API.ExternalClient.create_playlist" do

--- a/lib/setlistify/music_service/api.ex
+++ b/lib/setlistify/music_service/api.ex
@@ -13,7 +13,7 @@ defmodule Setlistify.MusicService.API do
 
   @type user_session :: Spotify.UserSession.t() | AppleMusic.UserSession.t()
 
-  @callback search_for_track(user_session(), String.t(), String.t()) ::
+  @callback search_for_track(user_session(), String.t(), String.t(), String.t() | nil) ::
               nil | %{track_id: String.t()}
 
   @callback create_playlist(user_session(), String.t(), String.t()) ::
@@ -32,16 +32,17 @@ defmodule Setlistify.MusicService.API do
     AppleMusic.API
   end
 
-  def search_for_track(user_session, artist, track) do
+  def search_for_track(user_session, artist, track, cover_artist \\ nil) do
     OpenTelemetry.Tracer.with_span "Setlistify.MusicService.API.search_for_track" do
       OpenTelemetry.Tracer.set_attributes([
         {"user.id", user_session.user_id},
         {"enduser.id", user_session.user_id},
         {"music.artist", artist},
-        {"music.track", track}
+        {"music.track", track},
+        {"music.cover_artist", cover_artist || ""}
       ])
 
-      impl(user_session).search_for_track(user_session, artist, track)
+      impl(user_session).search_for_track(user_session, artist, track, cover_artist)
     end
   end
 

--- a/lib/setlistify/music_service/api.ex
+++ b/lib/setlistify/music_service/api.ex
@@ -42,9 +42,20 @@ defmodule Setlistify.MusicService.API do
         {"music.cover_artist", cover_artist || ""}
       ])
 
-      impl(user_session).search_for_track(user_session, artist, track, cover_artist)
+      result = impl(user_session).search_for_track(user_session, artist, track, cover_artist)
+
+      OpenTelemetry.Tracer.set_attributes([
+        {"music.search.outcome", search_outcome(result)}
+      ])
+
+      result
     end
   end
+
+  defp search_outcome(%{track_id: _}), do: "match"
+  defp search_outcome(nil), do: "no_match"
+  defp search_outcome({:error, _}), do: "error"
+  defp search_outcome(_), do: "unknown"
 
   def create_playlist(user_session, name, description) do
     OpenTelemetry.Tracer.with_span "Setlistify.MusicService.API.create_playlist" do

--- a/lib/setlistify/music_service/api.ex
+++ b/lib/setlistify/music_service/api.ex
@@ -14,7 +14,7 @@ defmodule Setlistify.MusicService.API do
   @type user_session :: Spotify.UserSession.t() | AppleMusic.UserSession.t()
 
   @callback search_for_track(user_session(), String.t(), String.t(), String.t() | nil) ::
-              nil | %{track_id: String.t()}
+              nil | %{track_id: String.t()} | {:error, atom()}
 
   @callback create_playlist(user_session(), String.t(), String.t()) ::
               {:ok, %{id: String.t(), external_url: String.t()}} | {:error, atom()}

--- a/lib/setlistify/setlist_fm/api.ex
+++ b/lib/setlistify/setlist_fm/api.ex
@@ -49,7 +49,7 @@ defmodule Setlistify.SetlistFm.API do
   @type set :: %{
           optional(:encore) => integer(),
           name: nil | String.t(),
-          songs: [%{title: String.t(), cover_artist: String.t() | nil}]
+          songs: [%{:title => String.t(), optional(:cover_artist) => String.t()}]
         }
 
   @callback search(String.t(), pos_integer()) :: search_response()

--- a/lib/setlistify/setlist_fm/api.ex
+++ b/lib/setlistify/setlist_fm/api.ex
@@ -49,7 +49,7 @@ defmodule Setlistify.SetlistFm.API do
   @type set :: %{
           optional(:encore) => integer(),
           name: nil | String.t(),
-          songs: [%{title: String.t()}]
+          songs: [%{title: String.t(), cover_artist: String.t() | nil}]
         }
 
   @callback search(String.t(), pos_integer()) :: search_response()

--- a/lib/setlistify/setlist_fm/api/external_client.ex
+++ b/lib/setlistify/setlist_fm/api/external_client.ex
@@ -149,7 +149,16 @@ defmodule Setlistify.SetlistFm.API.ExternalClient do
 
           sets =
             Enum.map(sets, fn set ->
-              songs = set |> Map.get("song", []) |> Enum.map(&%{title: Map.get(&1, "name")})
+              songs =
+                set
+                |> Map.get("song", [])
+                |> Enum.map(fn song ->
+                  %{
+                    title: Map.get(song, "name"),
+                    cover_artist: song |> Map.get("cover", %{}) |> Map.get("name")
+                  }
+                end)
+
               %{name: set["name"], encore: set["encore"], songs: songs}
             end)
 

--- a/lib/setlistify/setlist_fm/api/external_client.ex
+++ b/lib/setlistify/setlist_fm/api/external_client.ex
@@ -149,16 +149,7 @@ defmodule Setlistify.SetlistFm.API.ExternalClient do
 
           sets =
             Enum.map(sets, fn set ->
-              songs =
-                set
-                |> Map.get("song", [])
-                |> Enum.map(fn song ->
-                  %{
-                    title: Map.get(song, "name"),
-                    cover_artist: song |> Map.get("cover", %{}) |> Map.get("name")
-                  }
-                end)
-
+              songs = set |> Map.get("song", []) |> Enum.map(&parse_song/1)
               %{name: set["name"], encore: set["encore"], songs: songs}
             end)
 
@@ -200,6 +191,15 @@ defmodule Setlistify.SetlistFm.API.ExternalClient do
       OpenTelemetry.Tracer.record_exception(error)
       OpenTelemetry.Tracer.set_status(:error, "Exception: #{Exception.message(error)}")
       reraise error, __STACKTRACE__
+  end
+
+  defp parse_song(song) do
+    base = %{title: Map.get(song, "name")}
+
+    case get_in(song, ["cover", "name"]) do
+      nil -> base
+      cover_artist -> Map.put(base, :cover_artist, cover_artist)
+    end
   end
 
   defp request(endpoint) do

--- a/lib/setlistify/spotify/api.ex
+++ b/lib/setlistify/spotify/api.ex
@@ -6,12 +6,14 @@ defmodule Setlistify.Spotify.API do
 
   require OpenTelemetry.Tracer
 
-  @callback search_for_track(UserSession.t(), String.t(), String.t()) ::
+  @callback search_for_track(UserSession.t(), String.t(), String.t(), String.t() | nil) ::
               nil | %{track_id: String.t()} | {:error, atom()}
-  def search_for_track(user_session, artist, track) do
-    Setlistify.Cache.fetch(:spotify_track_cache, {artist, track}, fn {artist, track} ->
-      impl().search_for_track(user_session, artist, track)
-    end)
+  def search_for_track(user_session, artist, track, cover_artist \\ nil) do
+    Setlistify.Cache.fetch(
+      :spotify_track_cache,
+      {artist, track, cover_artist},
+      fn _ -> impl().search_for_track(user_session, artist, track, cover_artist) end
+    )
   end
 
   @callback create_playlist(UserSession.t(), String.t(), String.t()) ::

--- a/lib/setlistify/spotify/api/external_client.ex
+++ b/lib/setlistify/spotify/api/external_client.ex
@@ -119,28 +119,7 @@ defmodule Setlistify.Spotify.API.ExternalClient do
     case with_token_refresh(user_session, request_fn, "track search") do
       {:ok, %{status: 200} = resp} ->
         items = resp.body |> Map.get("tracks", %{}) |> Map.get("items", [])
-
-        case List.first(items) do
-          nil ->
-            Logger.warning("No search results", %{artist: artist, track: track})
-            {:ok, :no_match}
-
-          track_info ->
-            result_artists = track_info |> Map.get("artists", []) |> Enum.map(& &1["name"])
-
-            if Enum.any?(result_artists, &artist_match?(artist, &1)) do
-              Logger.info("Found match", %{artist: artist, track: track})
-              {:ok, %{track_id: track_info["uri"]}}
-            else
-              Logger.warning("Rejected search result: artist mismatch", %{
-                queried_artist: artist,
-                returned_artists: result_artists,
-                track: track
-              })
-
-              {:ok, :no_match}
-            end
-        end
+        evaluate_search_result(List.first(items), artist, track)
 
       {:error, _} = error ->
         error
@@ -156,21 +135,35 @@ defmodule Setlistify.Spotify.API.ExternalClient do
     end
   end
 
+  defp evaluate_search_result(nil, artist, track) do
+    Logger.warning("No search results", %{artist: artist, track: track})
+    {:ok, :no_match}
+  end
+
+  defp evaluate_search_result(track_info, artist, track) do
+    result_artists = track_info |> Map.get("artists", []) |> Enum.map(& &1["name"])
+
+    if Enum.any?(result_artists, &artist_match?(artist, &1)) do
+      Logger.info("Found match", %{artist: artist, track: track})
+      {:ok, %{track_id: track_info["uri"]}}
+    else
+      Logger.warning("Rejected search result: artist mismatch", %{
+        queried_artist: artist,
+        returned_artists: result_artists,
+        track: track
+      })
+
+      {:ok, :no_match}
+    end
+  end
+
   defp artist_match?(_queried, nil), do: false
 
   defp artist_match?(queried, returned) do
-    q = normalize_artist(queried)
-    r = normalize_artist(returned)
-    q != "" and r != "" and (String.contains?(r, q) or String.contains?(q, r))
+    String.equivalent?(normalize_artist(queried), normalize_artist(returned))
   end
 
-  defp normalize_artist(name) do
-    name
-    |> String.downcase()
-    |> String.replace(~r/[^\p{L}\p{N}\s]/u, " ")
-    |> String.replace(~r/\s+/u, " ")
-    |> String.trim()
-  end
+  defp normalize_artist(name), do: name |> String.downcase() |> String.trim()
 
   def create_playlist(user_session, name, description) do
     OpenTelemetry.Tracer.with_span "Setlistify.Spotify.API.ExternalClient.create_playlist" do

--- a/lib/setlistify/spotify/api/external_client.ex
+++ b/lib/setlistify/spotify/api/external_client.ex
@@ -78,54 +78,26 @@ defmodule Setlistify.Spotify.API.ExternalClient do
     end
   end
 
-  def search_for_track(user_session, artist, track) do
+  def search_for_track(user_session, artist, track, cover_artist \\ nil) do
     OpenTelemetry.Tracer.with_span "Setlistify.Spotify.API.ExternalClient.search_for_track" do
-      request_fn = fn req ->
-        Req.get(req,
-          url: "/search",
-          params: %{q: "artist:#{artist} track:#{track}", type: "track"}
-        )
-      end
-
-      case with_token_refresh(user_session, request_fn, "track search") do
-        {:ok, %{status: 200} = resp} ->
-          items = resp.body |> Map.get("tracks", %{}) |> Map.get("items", [])
-
-          result =
-            case List.first(items) do
-              nil ->
-                Logger.warning("No search results", %{artist: artist, track: track})
-                OpenTelemetry.Tracer.set_attribute("results.count", 0)
-                nil
-
-              track_info ->
-                Logger.info("Found match", %{artist: artist, track: track})
-
-                OpenTelemetry.Tracer.set_attributes([
-                  {"results.count", length(items)},
-                  {"track.id", track_info["uri"]}
-                ])
-
-                %{track_id: track_info["uri"]}
-            end
-
-          OpenTelemetry.Tracer.set_status(:ok, "")
+      case do_search_for_track(user_session, artist, track) do
+        {:ok, %{track_id: _} = result} ->
           result
 
-        {:error, reason} = error ->
-          OpenTelemetry.Tracer.set_status(:error, inspect(reason))
+        {:ok, :no_match} when is_binary(cover_artist) ->
+          OpenTelemetry.Tracer.set_attributes([{"search.fallback", "cover_artist"}])
+
+          case do_search_for_track(user_session, cover_artist, track) do
+            {:ok, %{track_id: _} = result} -> result
+            {:ok, :no_match} -> nil
+            {:error, _} = error -> error
+          end
+
+        {:ok, :no_match} ->
+          nil
+
+        {:error, _} = error ->
           error
-
-        {:ok, %{status: 401} = response} ->
-          Logger.error("Unauthorized search request with user_id #{user_session.user_id}: #{inspect(response)}")
-
-          OpenTelemetry.Tracer.set_status(:error, "Unauthorized")
-          nil
-
-        {:ok, response} ->
-          Logger.error("Unexpected response from Spotify search: #{inspect(response)}")
-          OpenTelemetry.Tracer.set_status(:error, "Unexpected response")
-          nil
       end
     end
   rescue
@@ -134,6 +106,70 @@ defmodule Setlistify.Spotify.API.ExternalClient do
       OpenTelemetry.Tracer.record_exception(error)
       OpenTelemetry.Tracer.set_status(:error, "Exception: #{Exception.message(error)}")
       nil
+  end
+
+  defp do_search_for_track(user_session, artist, track) do
+    request_fn = fn req ->
+      Req.get(req,
+        url: "/search",
+        params: %{q: "artist:#{artist} track:#{track}", type: "track"}
+      )
+    end
+
+    case with_token_refresh(user_session, request_fn, "track search") do
+      {:ok, %{status: 200} = resp} ->
+        items = resp.body |> Map.get("tracks", %{}) |> Map.get("items", [])
+
+        case List.first(items) do
+          nil ->
+            Logger.warning("No search results", %{artist: artist, track: track})
+            {:ok, :no_match}
+
+          track_info ->
+            result_artists = track_info |> Map.get("artists", []) |> Enum.map(& &1["name"])
+
+            if Enum.any?(result_artists, &artist_match?(artist, &1)) do
+              Logger.info("Found match", %{artist: artist, track: track})
+              {:ok, %{track_id: track_info["uri"]}}
+            else
+              Logger.warning("Rejected search result: artist mismatch", %{
+                queried_artist: artist,
+                returned_artists: result_artists,
+                track: track
+              })
+
+              {:ok, :no_match}
+            end
+        end
+
+      {:error, _} = error ->
+        error
+
+      {:ok, %{status: 401} = response} ->
+        Logger.error("Unauthorized search request with user_id #{user_session.user_id}: #{inspect(response)}")
+
+        {:error, :unauthorized}
+
+      {:ok, response} ->
+        Logger.error("Unexpected response from Spotify search: #{inspect(response)}")
+        {:error, :unexpected_response}
+    end
+  end
+
+  defp artist_match?(_queried, nil), do: false
+
+  defp artist_match?(queried, returned) do
+    q = normalize_artist(queried)
+    r = normalize_artist(returned)
+    q != "" and r != "" and (String.contains?(r, q) or String.contains?(q, r))
+  end
+
+  defp normalize_artist(name) do
+    name
+    |> String.downcase()
+    |> String.replace(~r/[^\p{L}\p{N}\s]/u, " ")
+    |> String.replace(~r/\s+/u, " ")
+    |> String.trim()
   end
 
   def create_playlist(user_session, name, description) do

--- a/lib/setlistify/spotify/api/external_client.ex
+++ b/lib/setlistify/spotify/api/external_client.ex
@@ -137,6 +137,8 @@ defmodule Setlistify.Spotify.API.ExternalClient do
 
   defp evaluate_search_result(nil, artist, track) do
     Logger.warning("No search results", %{artist: artist, track: track})
+
+    OpenTelemetry.Tracer.set_attributes([{"search.outcome", "no_results"}])
     {:ok, :no_match}
   end
 
@@ -145,6 +147,12 @@ defmodule Setlistify.Spotify.API.ExternalClient do
 
     if Enum.any?(result_artists, &artist_match?(artist, &1)) do
       Logger.info("Found match", %{artist: artist, track: track})
+
+      OpenTelemetry.Tracer.set_attributes([
+        {"track.id", track_info["uri"]},
+        {"search.outcome", "match"}
+      ])
+
       {:ok, %{track_id: track_info["uri"]}}
     else
       Logger.warning("Rejected search result: artist mismatch", %{
@@ -152,6 +160,15 @@ defmodule Setlistify.Spotify.API.ExternalClient do
         returned_artists: result_artists,
         track: track
       })
+
+      OpenTelemetry.Tracer.set_attributes([{"search.outcome", "rejected_artist_mismatch"}])
+
+      OpenTelemetry.Tracer.add_event("search.result_rejected", [
+        {"reason", "artist_mismatch"},
+        {"queried_artist", artist},
+        {"returned_artists", Enum.join(result_artists, ", ")},
+        {"track", track}
+      ])
 
       {:ok, :no_match}
     end

--- a/lib/setlistify_web/live/setlists/show_live.ex
+++ b/lib/setlistify_web/live/setlists/show_live.ex
@@ -182,12 +182,18 @@ defmodule SetlistifyWeb.Setlists.ShowLive do
               {"music.service", provider(user_session)},
               {"music.track", song.title},
               {"music.artist", setlist.artist},
+              {"music.cover_artist", song.cover_artist || ""},
               {"song.set_index", set_index},
               {"song.song_index", song_index}
             ])
 
             track_info =
-              MusicService.API.search_for_track(user_session, setlist.artist, song.title)
+              MusicService.API.search_for_track(
+                user_session,
+                setlist.artist,
+                song.title,
+                song.cover_artist
+              )
 
             {:ok,
              %{

--- a/lib/setlistify_web/live/setlists/show_live.ex
+++ b/lib/setlistify_web/live/setlists/show_live.ex
@@ -178,11 +178,13 @@ defmodule SetlistifyWeb.Setlists.ShowLive do
         atom_key,
         fn ->
           OpenTelemetry.Tracer.with_span "SetlistifyWeb.Setlists.ShowLive.search_song_async" do
+            cover_artist = Map.get(song, :cover_artist)
+
             OpenTelemetry.Tracer.set_attributes([
               {"music.service", provider(user_session)},
               {"music.track", song.title},
               {"music.artist", setlist.artist},
-              {"music.cover_artist", song.cover_artist || ""},
+              {"music.cover_artist", cover_artist || ""},
               {"song.set_index", set_index},
               {"song.song_index", song_index}
             ])
@@ -192,7 +194,7 @@ defmodule SetlistifyWeb.Setlists.ShowLive do
                 user_session,
                 setlist.artist,
                 song.title,
-                song.cover_artist
+                cover_artist
               )
 
             {:ok,

--- a/test/setlistify/apple_music/api/external_client_test.exs
+++ b/test/setlistify/apple_music/api/external_client_test.exs
@@ -174,6 +174,69 @@ defmodule Setlistify.AppleMusic.API.ExternalClientTest do
                )
     end
 
+    test "returns nil when the cover artist fallback also returns a mismatched artist" do
+      # Performing-artist search misses, cover-artist fallback fires but the
+      # top-1 result is again from an unrelated artist — verify we don't slip
+      # through and return the bad fallback result.
+      Req.Test.expect(MyAppleMusicStub, fn %{query_string: qs} = conn ->
+        assert qs =~ "term=Tim+Kasher+Driftwood"
+        Req.Test.json(conn, %{"results" => %{"songs" => %{"data" => []}}})
+      end)
+
+      Req.Test.expect(MyAppleMusicStub, fn %{query_string: qs} = conn ->
+        assert qs =~ "term=Cursive+Driftwood"
+
+        Req.Test.json(conn, %{
+          "results" => %{
+            "songs" => %{
+              "data" => [
+                %{
+                  "id" => "99999",
+                  "type" => "songs",
+                  "attributes" => %{
+                    "artistName" => "Some Other Artist",
+                    "name" => "Driftwood"
+                  }
+                }
+              ]
+            }
+          }
+        })
+      end)
+
+      ExUnit.CaptureLog.capture_log(fn ->
+        assert ExternalClient.search_for_track(
+                 @user_session,
+                 "Tim Kasher",
+                 "Driftwood: A Fairy Tale",
+                 "Cursive"
+               ) == nil
+      end)
+    end
+
+    test "propagates primary search error without attempting cover artist fallback" do
+      # After with_developer_token_refresh exhausts its retry, an unauthorized
+      # error should bubble up — we should NOT try the cover_artist with a
+      # presumably-still-broken auth context.
+      Req.Test.expect(MyAppleMusicStub, fn conn ->
+        Plug.Conn.send_resp(conn, 401, "Unauthorized")
+      end)
+
+      Req.Test.expect(MyAppleMusicStub, fn conn ->
+        Plug.Conn.send_resp(conn, 401, "Unauthorized")
+      end)
+
+      ExUnit.CaptureLog.capture_log(fn ->
+        assert {:error, :unauthorized} =
+                 ExternalClient.search_for_track(
+                   @user_session,
+                   "Tim Kasher",
+                   "Driftwood: A Fairy Tale",
+                   "Cursive"
+                 )
+      end)
+    end
+
     test "uses performing artist first when it matches, without calling cover artist" do
       # Only the performing-artist call is expected; if a fallback fires the
       # test fails because Req.Test.verify_on_exit! sees an unconsumed expect.

--- a/test/setlistify/apple_music/api/external_client_test.exs
+++ b/test/setlistify/apple_music/api/external_client_test.exs
@@ -113,8 +113,22 @@ defmodule Setlistify.AppleMusic.API.ExternalClientTest do
       # "Tim Kasher From the Hips" and getting back a Labrinth song).
       Req.Test.stub(MyAppleMusicStub, fn
         %{request_path: "/v1/catalog/us/search"} = conn ->
-          response = mismatched_song_response("Labrinth", "Still Don't Know My Name")
-          Req.Test.json(conn, response)
+          Req.Test.json(conn, %{
+            "results" => %{
+              "songs" => %{
+                "data" => [
+                  %{
+                    "id" => "12345",
+                    "type" => "songs",
+                    "attributes" => %{
+                      "artistName" => "Labrinth",
+                      "name" => "Still Don't Know My Name"
+                    }
+                  }
+                ]
+              }
+            }
+          })
       end)
 
       ExUnit.CaptureLog.capture_log(fn ->
@@ -127,14 +141,28 @@ defmodule Setlistify.AppleMusic.API.ExternalClientTest do
       # Performing artist call returns no usable result, cover artist call hits.
       Req.Test.expect(MyAppleMusicStub, fn %{query_string: qs} = conn ->
         assert qs =~ "term=Tim+Kasher+Driftwood"
-        response = %{"results" => %{"songs" => %{"data" => []}}}
-        Req.Test.json(conn, response)
+        Req.Test.json(conn, %{"results" => %{"songs" => %{"data" => []}}})
       end)
 
       Req.Test.expect(MyAppleMusicStub, fn %{query_string: qs} = conn ->
         assert qs =~ "term=Cursive+Driftwood"
-        response = matching_song_response("Cursive", "Driftwood: A Fairy Tale", "1187475400")
-        Req.Test.json(conn, response)
+
+        Req.Test.json(conn, %{
+          "results" => %{
+            "songs" => %{
+              "data" => [
+                %{
+                  "id" => "1187475400",
+                  "type" => "songs",
+                  "attributes" => %{
+                    "artistName" => "Cursive",
+                    "name" => "Driftwood: A Fairy Tale"
+                  }
+                }
+              ]
+            }
+          }
+        })
       end)
 
       assert %{track_id: "1187475400"} =
@@ -151,8 +179,20 @@ defmodule Setlistify.AppleMusic.API.ExternalClientTest do
       # test fails because Req.Test.verify_on_exit! sees an unconsumed expect.
       Req.Test.expect(MyAppleMusicStub, fn %{query_string: qs} = conn ->
         assert qs =~ "term=Cursive+The+Recluse"
-        response = matching_song_response("Cursive", "The Recluse", "9999")
-        Req.Test.json(conn, response)
+
+        Req.Test.json(conn, %{
+          "results" => %{
+            "songs" => %{
+              "data" => [
+                %{
+                  "id" => "9999",
+                  "type" => "songs",
+                  "attributes" => %{"artistName" => "Cursive", "name" => "The Recluse"}
+                }
+              ]
+            }
+          }
+        })
       end)
 
       assert %{track_id: "9999"} =
@@ -311,25 +351,5 @@ defmodule Setlistify.AppleMusic.API.ExternalClientTest do
                  ["1441164430"]
                )
     end
-  end
-
-  defp matching_song_response(artist, track, id) do
-    %{
-      "results" => %{
-        "songs" => %{
-          "data" => [
-            %{
-              "id" => id,
-              "type" => "songs",
-              "attributes" => %{"artistName" => artist, "name" => track}
-            }
-          ]
-        }
-      }
-    }
-  end
-
-  defp mismatched_song_response(artist, track) do
-    matching_song_response(artist, track, "0000")
   end
 end

--- a/test/setlistify/apple_music/api/external_client_test.exs
+++ b/test/setlistify/apple_music/api/external_client_test.exs
@@ -218,11 +218,19 @@ defmodule Setlistify.AppleMusic.API.ExternalClientTest do
       # After with_developer_token_refresh exhausts its retry, an unauthorized
       # error should bubble up — we should NOT try the cover_artist with a
       # presumably-still-broken auth context.
-      Req.Test.expect(MyAppleMusicStub, fn conn ->
+      #
+      # Both expected requests query the primary artist ("Tim Kasher"): the
+      # first is the initial call, the second is the token-refresh retry
+      # inside with_developer_token_refresh. Neither should query "Cursive" —
+      # if the fallback wrongly fired we'd see a third request, and the
+      # assertions below would also catch a Cursive query in slot 2.
+      Req.Test.expect(MyAppleMusicStub, fn %{query_string: qs} = conn ->
+        assert qs =~ "term=Tim+Kasher+Driftwood"
         Plug.Conn.send_resp(conn, 401, "Unauthorized")
       end)
 
-      Req.Test.expect(MyAppleMusicStub, fn conn ->
+      Req.Test.expect(MyAppleMusicStub, fn %{query_string: qs} = conn ->
+        assert qs =~ "term=Tim+Kasher+Driftwood"
         Plug.Conn.send_resp(conn, 401, "Unauthorized")
       end)
 

--- a/test/setlistify/apple_music/api/external_client_test.exs
+++ b/test/setlistify/apple_music/api/external_client_test.exs
@@ -106,6 +106,63 @@ defmodule Setlistify.AppleMusic.API.ExternalClientTest do
                  ExternalClient.search_for_track(@user_session, "Artist", "Track")
       end)
     end
+
+    test "rejects results whose artist does not match the queried artist" do
+      # Mimics Apple Music returning an unrelated top-1 result when the
+      # queried artist never matches anywhere in the catalog (e.g. searching
+      # "Tim Kasher From the Hips" and getting back a Labrinth song).
+      Req.Test.stub(MyAppleMusicStub, fn
+        %{request_path: "/v1/catalog/us/search"} = conn ->
+          response = mismatched_song_response("Labrinth", "Still Don't Know My Name")
+          Req.Test.json(conn, response)
+      end)
+
+      ExUnit.CaptureLog.capture_log(fn ->
+        assert ExternalClient.search_for_track(@user_session, "Tim Kasher", "From the Hips") ==
+                 nil
+      end)
+    end
+
+    test "falls back to cover artist when performing artist returns no usable match" do
+      # Performing artist call returns no usable result, cover artist call hits.
+      Req.Test.expect(MyAppleMusicStub, fn %{query_string: qs} = conn ->
+        assert qs =~ "term=Tim+Kasher+Driftwood"
+        response = %{"results" => %{"songs" => %{"data" => []}}}
+        Req.Test.json(conn, response)
+      end)
+
+      Req.Test.expect(MyAppleMusicStub, fn %{query_string: qs} = conn ->
+        assert qs =~ "term=Cursive+Driftwood"
+        response = matching_song_response("Cursive", "Driftwood: A Fairy Tale", "1187475400")
+        Req.Test.json(conn, response)
+      end)
+
+      assert %{track_id: "1187475400"} =
+               ExternalClient.search_for_track(
+                 @user_session,
+                 "Tim Kasher",
+                 "Driftwood: A Fairy Tale",
+                 "Cursive"
+               )
+    end
+
+    test "uses performing artist first when it matches, without calling cover artist" do
+      # Only the performing-artist call is expected; if a fallback fires the
+      # test fails because Req.Test.verify_on_exit! sees an unconsumed expect.
+      Req.Test.expect(MyAppleMusicStub, fn %{query_string: qs} = conn ->
+        assert qs =~ "term=Cursive+The+Recluse"
+        response = matching_song_response("Cursive", "The Recluse", "9999")
+        Req.Test.json(conn, response)
+      end)
+
+      assert %{track_id: "9999"} =
+               ExternalClient.search_for_track(
+                 @user_session,
+                 "Cursive",
+                 "The Recluse",
+                 "Some Other Band"
+               )
+    end
   end
 
   describe "create_playlist/3" do
@@ -254,5 +311,25 @@ defmodule Setlistify.AppleMusic.API.ExternalClientTest do
                  ["1441164430"]
                )
     end
+  end
+
+  defp matching_song_response(artist, track, id) do
+    %{
+      "results" => %{
+        "songs" => %{
+          "data" => [
+            %{
+              "id" => id,
+              "type" => "songs",
+              "attributes" => %{"artistName" => artist, "name" => track}
+            }
+          ]
+        }
+      }
+    }
+  end
+
+  defp mismatched_song_response(artist, track) do
+    matching_song_response(artist, track, "0000")
   end
 end

--- a/test/setlistify/apple_music/api_test.exs
+++ b/test/setlistify/apple_music/api_test.exs
@@ -85,7 +85,7 @@ defmodule Setlistify.AppleMusic.APITest do
     test "returns the full error tuple when impl returns an error", %{
       user_session: user_session
     } do
-      expect(MockClient, :search_for_track, 1, fn _session, _artist, _track ->
+      expect(MockClient, :search_for_track, 1, fn _session, _artist, _track, _cover ->
         {:error, :token_refresh_failed}
       end)
 
@@ -94,7 +94,7 @@ defmodule Setlistify.AppleMusic.APITest do
     end
 
     test "caches successful results — impl is called only once", %{user_session: user_session} do
-      expect(MockClient, :search_for_track, 1, fn _session, _artist, _track ->
+      expect(MockClient, :search_for_track, 1, fn _session, _artist, _track, _cover ->
         %{track_id: "am:track:abc123"}
       end)
 

--- a/test/setlistify/setlist_fm/api/external_client_test.exs
+++ b/test/setlistify/setlist_fm/api/external_client_test.exs
@@ -466,24 +466,24 @@ defmodule Setlistify.SetlistFm.API.ExternalClientTest do
   test "get_setlist/1 surfaces cover_artist on songs originally performed by another band" do
     id = "4375bf0b"
 
-    Req.Test.expect(MySetlistFmStub, fn %{
-                                          request_path: "/rest/1.0/setlist/" <> rest,
-                                          method: "GET"
-                                        } = conn ->
-      assert rest == id
+    Req.Test.expect(
+      MySetlistFmStub,
+      fn %{request_path: "/rest/1.0/setlist/" <> rest, method: "GET"} = conn ->
+        assert rest == id
 
-      conn
-      |> Plug.Conn.put_resp_header("content-type", "application/json")
-      |> Plug.Conn.send_resp(200, @get_with_cover_response)
-    end)
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.send_resp(200, @get_with_cover_response)
+      end
+    )
 
     assert {:ok, result} = ExternalClient.get_setlist(id)
     assert result.artist == "Tim Kasher"
 
     songs = result.sets |> Enum.flat_map(& &1.songs) |> Map.new(&{&1.title, &1})
 
-    assert songs["Anonymity"] == %{title: "Anonymity", cover_artist: nil}
-    assert songs["Strays"] == %{title: "Strays", cover_artist: nil}
+    assert songs["Anonymity"] == %{title: "Anonymity"}
+    assert songs["Strays"] == %{title: "Strays"}
     assert songs["Needy"] == %{title: "Needy", cover_artist: "The Good Life"}
 
     assert songs["Driftwood: A Fairy Tale"] == %{

--- a/test/setlistify/setlist_fm/api/external_client_test.exs
+++ b/test/setlistify/setlist_fm/api/external_client_test.exs
@@ -460,6 +460,38 @@ defmodule Setlistify.SetlistFm.API.ExternalClientTest do
     end
   end
 
+  @get_with_cover_response fixture_dir()
+                           |> Path.join("setlist_fm_setlist_with_cover_response.json")
+                           |> File.read!()
+  test "get_setlist/1 surfaces cover_artist on songs originally performed by another band" do
+    id = "4375bf0b"
+
+    Req.Test.expect(MySetlistFmStub, fn %{
+                                          request_path: "/rest/1.0/setlist/" <> rest,
+                                          method: "GET"
+                                        } = conn ->
+      assert rest == id
+
+      conn
+      |> Plug.Conn.put_resp_header("content-type", "application/json")
+      |> Plug.Conn.send_resp(200, @get_with_cover_response)
+    end)
+
+    assert {:ok, result} = ExternalClient.get_setlist(id)
+    assert result.artist == "Tim Kasher"
+
+    songs = result.sets |> Enum.flat_map(& &1.songs) |> Map.new(&{&1.title, &1})
+
+    assert songs["Anonymity"] == %{title: "Anonymity", cover_artist: nil}
+    assert songs["Strays"] == %{title: "Strays", cover_artist: nil}
+    assert songs["Needy"] == %{title: "Needy", cover_artist: "The Good Life"}
+
+    assert songs["Driftwood: A Fairy Tale"] == %{
+             title: "Driftwood: A Fairy Tale",
+             cover_artist: "Cursive"
+           }
+  end
+
   describe "error handling" do
     test "search/2 returns error tuple on server error" do
       Req.Test.expect(MySetlistFmStub, fn

--- a/test/setlistify/spotify/api/external_client_test.exs
+++ b/test/setlistify/spotify/api/external_client_test.exs
@@ -69,8 +69,17 @@ defmodule Setlistify.Spotify.Api.ExternalClientTest do
          %{user_session: user_session} do
       Req.Test.stub(MySpotifyStub, fn
         %{request_path: "/v1/search", method: "GET"} = conn ->
-          response = track_response("Labrinth", "Still Don't Know My Name", "spotify:track:xyz")
-          Req.Test.json(conn, response)
+          Req.Test.json(conn, %{
+            "tracks" => %{
+              "items" => [
+                %{
+                  "uri" => "spotify:track:xyz",
+                  "name" => "Still Don't Know My Name",
+                  "artists" => [%{"name" => "Labrinth"}]
+                }
+              ]
+            }
+          })
       end)
 
       ExUnit.CaptureLog.capture_log(fn ->
@@ -88,10 +97,17 @@ defmodule Setlistify.Spotify.Api.ExternalClientTest do
       Req.Test.expect(MySpotifyStub, fn %{request_path: "/v1/search", query_string: qs} = conn ->
         assert qs =~ "artist%3ACursive"
 
-        Req.Test.json(
-          conn,
-          track_response("Cursive", "Driftwood: A Fairy Tale", "spotify:track:cursive1")
-        )
+        Req.Test.json(conn, %{
+          "tracks" => %{
+            "items" => [
+              %{
+                "uri" => "spotify:track:cursive1",
+                "name" => "Driftwood: A Fairy Tale",
+                "artists" => [%{"name" => "Cursive"}]
+              }
+            ]
+          }
+        })
       end)
 
       assert %{track_id: "spotify:track:cursive1"} =
@@ -108,10 +124,17 @@ defmodule Setlistify.Spotify.Api.ExternalClientTest do
       Req.Test.expect(MySpotifyStub, fn %{request_path: "/v1/search", query_string: qs} = conn ->
         assert qs =~ "artist%3ACursive"
 
-        Req.Test.json(
-          conn,
-          track_response("Cursive", "The Recluse", "spotify:track:recluse")
-        )
+        Req.Test.json(conn, %{
+          "tracks" => %{
+            "items" => [
+              %{
+                "uri" => "spotify:track:recluse",
+                "name" => "The Recluse",
+                "artists" => [%{"name" => "Cursive"}]
+              }
+            ]
+          }
+        })
       end)
 
       assert %{track_id: "spotify:track:recluse"} =
@@ -122,20 +145,6 @@ defmodule Setlistify.Spotify.Api.ExternalClientTest do
                  "Some Other Band"
                )
     end
-  end
-
-  defp track_response(artist, name, uri) do
-    %{
-      "tracks" => %{
-        "items" => [
-          %{
-            "uri" => uri,
-            "name" => name,
-            "artists" => [%{"name" => artist}]
-          }
-        ]
-      }
-    }
   end
 
   describe "create_playlist/3" do

--- a/test/setlistify/spotify/api/external_client_test.exs
+++ b/test/setlistify/spotify/api/external_client_test.exs
@@ -45,7 +45,7 @@ defmodule Setlistify.Spotify.Api.ExternalClientTest do
           |> Plug.Conn.send_resp(200, JSON.encode!(JSON.decode!(@search_response)))
       end)
 
-      result = ExternalClient.search_for_track(user_session, "some artist", "some track")
+      result = ExternalClient.search_for_track(user_session, "Modest Mouse", "Lace Your Shoes")
 
       assert result.track_id =~ ~r"spotify:track:\w+"
     end
@@ -64,6 +64,78 @@ defmodule Setlistify.Spotify.Api.ExternalClientTest do
         assert ExternalClient.search_for_track(user_session, "some artist", "some track") == nil
       end)
     end
+
+    test "rejects results whose artist does not match the queried artist",
+         %{user_session: user_session} do
+      Req.Test.stub(MySpotifyStub, fn
+        %{request_path: "/v1/search", method: "GET"} = conn ->
+          response = track_response("Labrinth", "Still Don't Know My Name", "spotify:track:xyz")
+          Req.Test.json(conn, response)
+      end)
+
+      ExUnit.CaptureLog.capture_log(fn ->
+        assert ExternalClient.search_for_track(user_session, "Tim Kasher", "From the Hips") == nil
+      end)
+    end
+
+    test "falls back to cover artist when performing artist returns no usable match",
+         %{user_session: user_session} do
+      Req.Test.expect(MySpotifyStub, fn %{request_path: "/v1/search", query_string: qs} = conn ->
+        assert qs =~ "artist%3ATim+Kasher"
+        Req.Test.json(conn, %{"tracks" => %{"items" => []}})
+      end)
+
+      Req.Test.expect(MySpotifyStub, fn %{request_path: "/v1/search", query_string: qs} = conn ->
+        assert qs =~ "artist%3ACursive"
+
+        Req.Test.json(
+          conn,
+          track_response("Cursive", "Driftwood: A Fairy Tale", "spotify:track:cursive1")
+        )
+      end)
+
+      assert %{track_id: "spotify:track:cursive1"} =
+               ExternalClient.search_for_track(
+                 user_session,
+                 "Tim Kasher",
+                 "Driftwood: A Fairy Tale",
+                 "Cursive"
+               )
+    end
+
+    test "uses performing artist first when it matches, without calling cover artist",
+         %{user_session: user_session} do
+      Req.Test.expect(MySpotifyStub, fn %{request_path: "/v1/search", query_string: qs} = conn ->
+        assert qs =~ "artist%3ACursive"
+
+        Req.Test.json(
+          conn,
+          track_response("Cursive", "The Recluse", "spotify:track:recluse")
+        )
+      end)
+
+      assert %{track_id: "spotify:track:recluse"} =
+               ExternalClient.search_for_track(
+                 user_session,
+                 "Cursive",
+                 "The Recluse",
+                 "Some Other Band"
+               )
+    end
+  end
+
+  defp track_response(artist, name, uri) do
+    %{
+      "tracks" => %{
+        "items" => [
+          %{
+            "uri" => uri,
+            "name" => name,
+            "artists" => [%{"name" => artist}]
+          }
+        ]
+      }
+    }
   end
 
   describe "create_playlist/3" do
@@ -875,8 +947,8 @@ defmodule Setlistify.Spotify.Api.ExternalClientTest do
       result =
         ExternalClient.search_for_track(
           user_session,
-          "some artist",
-          "some track"
+          "Modest Mouse",
+          "Lace Your Shoes"
         )
 
       # The implementation should:

--- a/test/setlistify/spotify/api/external_client_test.exs
+++ b/test/setlistify/spotify/api/external_client_test.exs
@@ -119,6 +119,62 @@ defmodule Setlistify.Spotify.Api.ExternalClientTest do
                )
     end
 
+    test "returns nil when the cover artist fallback also returns a mismatched artist",
+         %{user_session: user_session} do
+      # Performing-artist search misses, cover-artist fallback fires but the
+      # top-1 result is again from an unrelated artist — verify we don't slip
+      # through and return the bad fallback result.
+      Req.Test.expect(MySpotifyStub, fn %{request_path: "/v1/search", query_string: qs} = conn ->
+        assert qs =~ "artist%3ATim+Kasher"
+        Req.Test.json(conn, %{"tracks" => %{"items" => []}})
+      end)
+
+      Req.Test.expect(MySpotifyStub, fn %{request_path: "/v1/search", query_string: qs} = conn ->
+        assert qs =~ "artist%3ACursive"
+
+        Req.Test.json(conn, %{
+          "tracks" => %{
+            "items" => [
+              %{
+                "uri" => "spotify:track:bogus",
+                "name" => "Driftwood",
+                "artists" => [%{"name" => "Some Other Artist"}]
+              }
+            ]
+          }
+        })
+      end)
+
+      ExUnit.CaptureLog.capture_log(fn ->
+        assert ExternalClient.search_for_track(
+                 user_session,
+                 "Tim Kasher",
+                 "Driftwood: A Fairy Tale",
+                 "Cursive"
+               ) == nil
+      end)
+    end
+
+    test "propagates primary search error without attempting cover artist fallback",
+         %{user_session: user_session} do
+      # An unexpected non-2xx from the primary search should bubble up. The
+      # cover_artist fallback should NOT fire — only the first call is
+      # expected (verify_on_exit! catches an unconsumed second expect).
+      Req.Test.expect(MySpotifyStub, fn %{request_path: "/v1/search"} = conn ->
+        Plug.Conn.send_resp(conn, 500, "Internal Server Error")
+      end)
+
+      ExUnit.CaptureLog.capture_log(fn ->
+        assert {:error, :unexpected_response} =
+                 ExternalClient.search_for_track(
+                   user_session,
+                   "Tim Kasher",
+                   "Driftwood: A Fairy Tale",
+                   "Cursive"
+                 )
+      end)
+    end
+
     test "uses performing artist first when it matches, without calling cover artist",
          %{user_session: user_session} do
       Req.Test.expect(MySpotifyStub, fn %{request_path: "/v1/search", query_string: qs} = conn ->

--- a/test/setlistify/spotify/api/external_client_test.exs
+++ b/test/setlistify/spotify/api/external_client_test.exs
@@ -158,9 +158,13 @@ defmodule Setlistify.Spotify.Api.ExternalClientTest do
     test "propagates primary search error without attempting cover artist fallback",
          %{user_session: user_session} do
       # An unexpected non-2xx from the primary search should bubble up. The
-      # cover_artist fallback should NOT fire — only the first call is
-      # expected (verify_on_exit! catches an unconsumed second expect).
-      Req.Test.expect(MySpotifyStub, fn %{request_path: "/v1/search"} = conn ->
+      # cover_artist fallback should NOT fire — only one request is expected
+      # (Spotify's with_token_refresh only retries on 401 with invalid_token,
+      # so a 500 doesn't trigger a retry either) and it should query the
+      # primary artist, not the cover artist.
+      Req.Test.expect(MySpotifyStub, fn %{request_path: "/v1/search", query_string: qs} = conn ->
+        assert qs =~ "artist%3ATim+Kasher"
+        refute qs =~ "Cursive"
         Plug.Conn.send_resp(conn, 500, "Internal Server Error")
       end)
 

--- a/test/setlistify/spotify/api_test.exs
+++ b/test/setlistify/spotify/api_test.exs
@@ -76,7 +76,7 @@ defmodule Setlistify.Spotify.APITest do
     test "returns the full error tuple when impl returns an error", %{
       user_session: user_session
     } do
-      expect(MockClient, :search_for_track, 1, fn _session, _artist, _track ->
+      expect(MockClient, :search_for_track, 1, fn _session, _artist, _track, _cover ->
         {:error, :token_refresh_failed}
       end)
 
@@ -85,7 +85,7 @@ defmodule Setlistify.Spotify.APITest do
     end
 
     test "caches successful results — impl is called only once", %{user_session: user_session} do
-      expect(MockClient, :search_for_track, 1, fn _session, _artist, _track ->
+      expect(MockClient, :search_for_track, 1, fn _session, _artist, _track, _cover ->
         %{track_id: "spotify:track:abc123"}
       end)
 

--- a/test/setlistify_web/live/setlists/show_live_test.exs
+++ b/test/setlistify_web/live/setlists/show_live_test.exs
@@ -46,15 +46,15 @@ defmodule SetlistifyWeb.Setlists.ShowLiveTest do
          },
          date: Date.new!(2023, 01, 01),
          sets: [
-           %{name: "Warm up", songs: [%{title: "a warm up song", cover_artist: nil}]},
+           %{name: "Warm up", songs: [%{title: "a warm up song"}]},
            %{
              name: nil,
-             songs: [%{title: "main set song1", cover_artist: nil}, %{title: "main set song2", cover_artist: nil}]
+             songs: [%{title: "main set song1"}, %{title: "main set song2"}]
            },
            %{
              name: nil,
              encore: 1,
-             songs: [%{title: "encore song1", cover_artist: nil}, %{title: "encore song2", cover_artist: nil}]
+             songs: [%{title: "encore song1"}, %{title: "encore song2"}]
            }
          ]
        }}
@@ -90,7 +90,7 @@ defmodule SetlistifyWeb.Setlists.ShowLiveTest do
          },
          date: Date.new!(2023, 01, 01),
          sets: [
-           %{name: "Main", songs: [%{title: "Hey Jude", cover_artist: nil}]}
+           %{name: "Main", songs: [%{title: "Hey Jude"}]}
          ]
        }}
     end)
@@ -135,7 +135,7 @@ defmodule SetlistifyWeb.Setlists.ShowLiveTest do
            }
          },
          date: Date.utc_today(),
-         sets: [%{name: nil, songs: [%{title: "song1", cover_artist: nil}, %{title: "song2", cover_artist: nil}]}]
+         sets: [%{name: nil, songs: [%{title: "song1"}, %{title: "song2"}]}]
        }}
     end)
 
@@ -199,7 +199,7 @@ defmodule SetlistifyWeb.Setlists.ShowLiveTest do
            }
          },
          date: Date.utc_today(),
-         sets: [%{name: nil, songs: [%{title: "song1", cover_artist: nil}, %{title: "song2", cover_artist: nil}]}]
+         sets: [%{name: nil, songs: [%{title: "song1"}, %{title: "song2"}]}]
        }}
     end)
 
@@ -278,7 +278,7 @@ defmodule SetlistifyWeb.Setlists.ShowLiveTest do
            }
          },
          date: Date.utc_today(),
-         sets: [%{name: nil, songs: [%{title: "song1", cover_artist: nil}, %{title: "song2", cover_artist: nil}]}]
+         sets: [%{name: nil, songs: [%{title: "song1"}, %{title: "song2"}]}]
        }}
     end)
 
@@ -333,7 +333,7 @@ defmodule SetlistifyWeb.Setlists.ShowLiveTest do
            }
          },
          date: Date.utc_today(),
-         sets: [%{name: nil, songs: [%{title: "song1", cover_artist: nil}, %{title: "song2", cover_artist: nil}]}]
+         sets: [%{name: nil, songs: [%{title: "song1"}, %{title: "song2"}]}]
        }}
     end)
 
@@ -404,7 +404,7 @@ defmodule SetlistifyWeb.Setlists.ShowLiveTest do
            }
          },
          date: Date.utc_today(),
-         sets: [%{name: nil, songs: [%{title: "Hey Jude", cover_artist: nil}]}]
+         sets: [%{name: nil, songs: [%{title: "Hey Jude"}]}]
        }}
     end)
 

--- a/test/setlistify_web/live/setlists/show_live_test.exs
+++ b/test/setlistify_web/live/setlists/show_live_test.exs
@@ -46,9 +46,16 @@ defmodule SetlistifyWeb.Setlists.ShowLiveTest do
          },
          date: Date.new!(2023, 01, 01),
          sets: [
-           %{name: "Warm up", songs: [%{title: "a warm up song"}]},
-           %{name: nil, songs: [%{title: "main set song1"}, %{title: "main set song2"}]},
-           %{name: nil, encore: 1, songs: [%{title: "encore song1"}, %{title: "encore song2"}]}
+           %{name: "Warm up", songs: [%{title: "a warm up song", cover_artist: nil}]},
+           %{
+             name: nil,
+             songs: [%{title: "main set song1", cover_artist: nil}, %{title: "main set song2", cover_artist: nil}]
+           },
+           %{
+             name: nil,
+             encore: 1,
+             songs: [%{title: "encore song1", cover_artist: nil}, %{title: "encore song2", cover_artist: nil}]
+           }
          ]
        }}
     end)
@@ -83,7 +90,7 @@ defmodule SetlistifyWeb.Setlists.ShowLiveTest do
          },
          date: Date.new!(2023, 01, 01),
          sets: [
-           %{name: "Main", songs: [%{title: "Hey Jude"}]}
+           %{name: "Main", songs: [%{title: "Hey Jude", cover_artist: nil}]}
          ]
        }}
     end)
@@ -128,11 +135,11 @@ defmodule SetlistifyWeb.Setlists.ShowLiveTest do
            }
          },
          date: Date.utc_today(),
-         sets: [%{name: nil, songs: [%{title: "song1"}, %{title: "song2"}]}]
+         sets: [%{name: nil, songs: [%{title: "song1", cover_artist: nil}, %{title: "song2", cover_artist: nil}]}]
        }}
     end)
 
-    expect(Spotify.API.MockClient, :search_for_track, 2, fn _user_session, _artist, title ->
+    expect(Spotify.API.MockClient, :search_for_track, 2, fn _user_session, _artist, title, _cover ->
       case title do
         "song1" ->
           # We have a match for song
@@ -192,11 +199,11 @@ defmodule SetlistifyWeb.Setlists.ShowLiveTest do
            }
          },
          date: Date.utc_today(),
-         sets: [%{name: nil, songs: [%{title: "song1"}, %{title: "song2"}]}]
+         sets: [%{name: nil, songs: [%{title: "song1", cover_artist: nil}, %{title: "song2", cover_artist: nil}]}]
        }}
     end)
 
-    expect(Spotify.API.MockClient, :search_for_track, 2, fn _user_session, _artist, title ->
+    expect(Spotify.API.MockClient, :search_for_track, 2, fn _user_session, _artist, title, _cover ->
       case title do
         "song1" ->
           # We have a match for song
@@ -271,11 +278,11 @@ defmodule SetlistifyWeb.Setlists.ShowLiveTest do
            }
          },
          date: Date.utc_today(),
-         sets: [%{name: nil, songs: [%{title: "song1"}, %{title: "song2"}]}]
+         sets: [%{name: nil, songs: [%{title: "song1", cover_artist: nil}, %{title: "song2", cover_artist: nil}]}]
        }}
     end)
 
-    expect(AppleMusic.API.MockClient, :search_for_track, 2, fn _user_session, _artist, title ->
+    expect(AppleMusic.API.MockClient, :search_for_track, 2, fn _user_session, _artist, title, _cover ->
       case title do
         "song1" ->
           %{track_id: "apple_music:track:456"}
@@ -326,11 +333,11 @@ defmodule SetlistifyWeb.Setlists.ShowLiveTest do
            }
          },
          date: Date.utc_today(),
-         sets: [%{name: nil, songs: [%{title: "song1"}, %{title: "song2"}]}]
+         sets: [%{name: nil, songs: [%{title: "song1", cover_artist: nil}, %{title: "song2", cover_artist: nil}]}]
        }}
     end)
 
-    expect(AppleMusic.API.MockClient, :search_for_track, 2, fn _user_session, _artist, title ->
+    expect(AppleMusic.API.MockClient, :search_for_track, 2, fn _user_session, _artist, title, _cover ->
       case title do
         "song1" ->
           %{track_id: "apple_music:track:456"}
@@ -397,11 +404,11 @@ defmodule SetlistifyWeb.Setlists.ShowLiveTest do
            }
          },
          date: Date.utc_today(),
-         sets: [%{name: nil, songs: [%{title: "Hey Jude"}]}]
+         sets: [%{name: nil, songs: [%{title: "Hey Jude", cover_artist: nil}]}]
        }}
     end)
 
-    expect(AppleMusic.API.MockClient, :search_for_track, 1, fn _user_session, _artist, _title ->
+    expect(AppleMusic.API.MockClient, :search_for_track, 1, fn _user_session, _artist, _title, _cover ->
       %{track_id: "apple_music:track:789"}
     end)
 

--- a/test/support/fixtures/setlist_fm_setlist_with_cover_response.json
+++ b/test/support/fixtures/setlist_fm_setlist_with_cover_response.json
@@ -1,0 +1,57 @@
+{
+  "id": "4375bf0b",
+  "versionId": "g7b1d7228",
+  "eventDate": "23-05-2026",
+  "lastUpdated": "2026-05-24T21:21:35.780+0000",
+  "artist": {
+    "mbid": "22dbe176-9b9b-4c2c-b84b-a2f3aa0cf355",
+    "name": "Tim Kasher",
+    "sortName": "Kasher, Tim",
+    "disambiguation": "",
+    "url": "https://www.setlist.fm/setlists/tim-kasher-6bd6ca56.html"
+  },
+  "venue": {
+    "id": "1bd6c528",
+    "name": "The Bottleneck",
+    "city": {
+      "id": "4274277",
+      "name": "Lawrence",
+      "state": "Kansas",
+      "stateCode": "KS",
+      "coords": {"lat": 38.9716689, "long": -95.2352501},
+      "country": {"code": "US", "name": "United States"}
+    },
+    "url": "https://www.setlist.fm/venue/the-bottleneck-lawrence-ks-usa-1bd6c528.html"
+  },
+  "sets": {
+    "set": [
+      {
+        "song": [
+          {"name": "Anonymity", "info": "First time ever played live"},
+          {
+            "name": "Needy",
+            "cover": {
+              "mbid": "0ad7bbcd-6e77-4dc0-bb61-e331c46f70ec",
+              "name": "The Good Life",
+              "sortName": "Good Life, The",
+              "disambiguation": "US indie rock band",
+              "url": "https://www.setlist.fm/setlists/the-good-life-4bd69ba6.html"
+            }
+          },
+          {
+            "name": "Driftwood: A Fairy Tale",
+            "cover": {
+              "mbid": "c4153c51-b4ac-4183-beb3-c5dbfce39176",
+              "name": "Cursive",
+              "sortName": "Cursive",
+              "disambiguation": "Omaha indie rock",
+              "url": "https://www.setlist.fm/setlists/cursive-23d6d8df.html"
+            }
+          },
+          {"name": "Strays"}
+        ]
+      }
+    ]
+  },
+  "url": "https://www.setlist.fm/setlist/tim-kasher/2026/the-bottleneck-lawrence-ks-4375bf0b.html"
+}


### PR DESCRIPTION
## Summary

Fixes a search bug where Apple Music was silently inserting wildly wrong tracks into playlists for setlist songs originally performed by a different band — e.g. Labrinth's *Still Don't Know My Name* for Tim Kasher's *From the Hips*, or Tyler, the Creator's *I Ain't Got Time!* for *Album of the Year*. Driftwood-style songs that simply went missing are now found.

Two things were happening:
1. Apple Music's free-text `term` search returns a fuzzy top-1 result even when none of the query tokens really hit, so side-project songs (e.g. a Cursive track in a Tim Kasher solo show) either missed entirely or got matched to an unrelated artist.
2. We had no check that the returned track's artist resembled the requested one, so garbage results were accepted as-is.

This PR:

- Parses the `cover` field from setlist.fm responses and surfaces it as `cover_artist` on each song.
- Adds normalized artist validation to both Apple Music and Spotify search results — rejects matches whose returned artist doesn't loosely match the queried one.
- Falls back to the originating band (from `cover_artist`) when the performing-artist search yields no usable match. Validates the fallback against the cover artist too.
- Plumbs `cover_artist` from setlist.fm through `MusicService.API` to the providers.

The validation + fallback currently lives in the external clients. That layering is debated and tracked in #130 for a follow-up refactor.

## Test plan

- [x] `mix test` — 261 tests, 0 failures
- [x] `mix format` clean
- [x] `mix credo --strict` — only soft nesting-depth suggestions, consistent with existing patterns
- [ ] Manually re-run the Tim Kasher setlist (`/setlist/4375bf0b`) on Apple Music in prod and confirm:
  - Driftwood: A Fairy Tale now appears (Cursive fallback)
  - From the Hips / Album of the Year no longer appear as Labrinth / Tyler, the Creator
- [ ] Spot-check a setlist with no covers to confirm no regression

Refs #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)