### PR TITLE
ci: harden SessionStart hook against transient failures

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -10,6 +10,25 @@
 
 set -euo pipefail
 
+# Retry a command up to 3 times with exponential backoff (2s, 4s). hex.pm
+# occasionally returns 503 from builds.hex.pm or trips transient DNS errors
+# on this base image; without retries one blip leaves the environment
+# half-installed and breaks `mix test` for the rest of the session.
+# Progress messages go to stderr so callers can `>/dev/null` the wrapped
+# command's stdout without hiding the retry log.
+retry() {
+  local attempt=1 delay=2
+  until "$@"; do
+    if [ "$attempt" -ge 3 ]; then
+      return 1
+    fi
+    echo "==> ${*@Q} failed (attempt $attempt); retrying in ${delay}s..." >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+    delay=$((delay * 2))
+  done
+}
+
 if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
   exit 0
 fi
@@ -20,16 +39,24 @@ SYSTEM_PACKAGES=(libssl3 libncurses6 unzip ca-certificates gh)
 
 if ! dpkg -s "${SYSTEM_PACKAGES[@]}" >/dev/null 2>&1; then
   echo "==> Installing system packages (${SYSTEM_PACKAGES[*]})..."
-  apt-get update -qq
-  DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends \
+  retry apt-get update -qq
+  retry env DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends \
     "${SYSTEM_PACKAGES[@]}" >/dev/null
 fi
 
 export MISE_DATA_DIR="${MISE_DATA_DIR:-$HOME/.local/share/mise}"
 
-if ! command -v mise >/dev/null 2>&1; then
-  echo "==> Installing mise..."
+# `curl | sh` is a pipeline, so wrap it in a function — that way retry retries
+# the whole pipeline (including the inherited `pipefail`) instead of just curl.
+install_mise() {
   curl -fsSL https://mise.run | sh
+}
+
+# `mise --version` rather than `command -v mise` so a half-installed binary
+# from a previous failed run is replaced instead of silently passing the check.
+if ! mise --version >/dev/null 2>&1; then
+  echo "==> Installing mise..."
+  retry install_mise
 fi
 export PATH="$HOME/.local/bin:$MISE_DATA_DIR/shims:$PATH"
 
@@ -37,38 +64,29 @@ export PATH="$HOME/.local/bin:$MISE_DATA_DIR/shims:$PATH"
 mise trust "$CLAUDE_PROJECT_DIR/.mise.toml" >/dev/null
 
 echo "==> Installing Erlang/Elixir via mise (precompiled)..."
-mise install
+retry mise install
 
 # Point Hex/Erlang at the system CA bundle. Without this, `mix deps.get` fails
 # with "TLS client: Unknown CA" against repo.hex.pm on this base image.
 export HEX_CACERTS_PATH="/etc/ssl/certs/ca-certificates.crt"
 
 # Hex's parallel registry fetch trips spurious "DNS resolution failure" errors
-# in this sandbox; serialising the requests avoids them.
+# in this sandbox; serialising the requests avoids them. Scoped to this script
+# only — persisting it would slow every later `mix deps.get` in the session
+# even when the DNS issue isn't biting.
 export HEX_HTTP_CONCURRENCY=1
 
-{
-  echo "export PATH=\"$HOME/.local/bin:$MISE_DATA_DIR/shims:\$PATH\""
-  echo "export HEX_CACERTS_PATH=\"/etc/ssl/certs/ca-certificates.crt\""
-  echo "export HEX_HTTP_CONCURRENCY=1"
-} >> "$CLAUDE_ENV_FILE"
-
-# Retry a command up to 3 times with exponential backoff (2s, 4s). hex.pm
-# occasionally returns 503 from builds.hex.pm or trips transient DNS errors
-# on this base image; without retries one blip leaves the environment
-# half-installed and breaks `mix test` for the rest of the session.
-retry() {
-  local attempt=1 delay=2
-  until "$@"; do
-    if [ "$attempt" -ge 3 ]; then
-      return 1
-    fi
-    echo "==> '$*' failed (attempt $attempt); retrying in ${delay}s..."
-    sleep "$delay"
-    attempt=$((attempt + 1))
-    delay=$((delay * 2))
-  done
+# Persist env exports for later shells in this session. Guard against duplicate
+# appends so re-runs of the hook (resume, etc.) don't pile up the same lines.
+append_env() {
+  local line="$1"
+  if ! grep -qxF "$line" "$CLAUDE_ENV_FILE" 2>/dev/null; then
+    echo "$line" >> "$CLAUDE_ENV_FILE"
+  fi
 }
+
+append_env "export PATH=\"$HOME/.local/bin:$MISE_DATA_DIR/shims:\$PATH\""
+append_env "export HEX_CACERTS_PATH=\"/etc/ssl/certs/ca-certificates.crt\""
 
 # runtime.exs loads `.env` for :dev (and `.env.example` for :test). Seed `.env`
 # with the same placeholders so dev compile/boot doesn't blow up on

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,7 @@
   "hooks": {
     "SessionStart": [
       {
+        "matcher": "startup|resume",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
Addresses the actionable findings from the code review on #127.

## Changes

- **Wrap the right network calls in `retry`.** The script comment justifies retries with "builds.hex.pm 503s", but the only call hitting builds.hex.pm (`mise install`) ran bare. Now `apt-get update`, `apt-get install`, `curl https://mise.run | sh`, and `mise install` are all wrapped. Also moves the `retry` definition above the first network call so all calls can use it.
- **Scope hook to `startup|resume`.** Previously omitting `matcher` meant the hook re-fired on `/clear` and `/compact` mid-session, triggering apt probes and `mix deps.get` round-trips the user never asked for.
- **Self-heal partial mise installs.** Use `mise --version` instead of `command -v mise` so a half-installed binary from a previous interrupted run gets replaced instead of silently passing the check.
- **Surface retry progress.** Retry's "failed (attempt N); retrying in Ns..." now goes to stderr so the `>/dev/null` on `retry mix local.hex ...` no longer hides it.
- **Stop persisting `HEX_HTTP_CONCURRENCY=1`.** It was being written to `$CLAUDE_ENV_FILE`, which slowed every later `mix deps.get` in the session and couldn't be `unset` by Claude. Now scoped to the script's process only.
- **Dedupe env-file appends.** A `grep -qxF` guard prevents the `PATH` / `HEX_CACERTS_PATH` exports from piling up if the hook re-fires against the same env file.
- **Safer retry diagnostic.** `${*@Q}` in the failure echo for multi-word args.

## Findings deferred

The following were discussed and intentionally left for follow-up:

- `[settings.erlang] compile = false` in shared `.mise.toml` (will address if it bites a teammate).
- `.env` seeded with `.env.example` placeholders (acceptable while we only need compile/test; address when something actually wants real API keys).
- Dropped `mix compile` from the hook (intentional tradeoff for faster session start).
- `mise.run` not version-pinned (address if it breaks).
- Bare `$CLAUDE_PROJECT_DIR` / `$CLAUDE_ENV_FILE` under `set -u` (address if the harness changes contract).

## Test plan

- [x] `bash -n .claude/hooks/session-start.sh` passes
- [x] `python3 -c "import json; json.load(open('.claude/settings.json'))"` passes
- [x] `mix test` passes locally in the web session (254 tests, 1 doctest, 0 failures)
- [x] `${*@Q}` expansion verified on the base-image bash (5.2.21)
- [x] Synthetic test: `retry false >/dev/null` shows progress messages and returns exit 1 after 3 attempts

https://claude.ai/code/session_0158zMebdLt6vUsp7b2WAjE9

---
_Generated by [Claude Code](https://claude.ai/code/session_0158zMebdLt6vUsp7b2WAjE9)_