### PR TITLE
chore: ignore .claude/worktrees subagent worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ npm-debug.log
 /priv/plts/*.plt.hash
 
 **/.claude/settings.local.json
+**/.claude/worktrees/
 
 # OpenTelemetry Docker data directories
 docker/tempo-data/


### PR DESCRIPTION
## Summary
Add `**/.claude/worktrees/` to `.gitignore` so subagent worktrees (created when Claude Code runs agents with `isolation: "worktree"`) don't show up as untracked changes in the host repo.

## Test plan
- [ ] `git status` reports a clean working tree even when one or more `.claude/worktrees/agent-*/` directories exist
- [ ] Existing entries (e.g. `**/.claude/settings.local.json`) remain effective

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiH8yEJTEaC9kXv2VcQXgz)_