### PR TITLE
chore: use HEEx comment syntax in templates (#154)

### DIFF
--- a/lib/setlistify_web/components/core_components.ex
+++ b/lib/setlistify_web/components/core_components.ex
@@ -696,12 +696,12 @@ defmodule SetlistifyWeb.CoreComponents do
   def logo(assigns) do
     ~H"""
     <div class="w-8 h-8 bg-emerald-500 rounded-full flex items-center justify-center relative">
-      <!-- Record grooves with better spacing and contrast -->
+      <%!-- Record grooves with better spacing and contrast --%>
       <div class="absolute w-7 h-7 border-[1.5px] border-black/20 rounded-full"></div>
       <div class="absolute w-5 h-5 border-[1.5px] border-black/20 rounded-full"></div>
       <div class="absolute w-3 h-3 border border-black/20 rounded-full"></div>
-      
-    <!-- Center hole -->
+
+      <%!-- Center hole --%>
       <div class="w-2 h-2 bg-black rounded-full"></div>
     </div>
     """

--- a/lib/setlistify_web/live/search_live.ex
+++ b/lib/setlistify_web/live/search_live.ex
@@ -168,7 +168,7 @@ defmodule SetlistifyWeb.SearchLive do
     ~H"""
     <nav class="flex justify-center mt-8" aria-label="Pagination Navigation">
       <div class="flex items-center gap-6">
-        <!-- Previous -->
+        <%!-- Previous --%>
         <%= if @page > 1 do %>
           <.link
             navigate={build_pagination_url(@query, @page - 1)}
@@ -181,13 +181,13 @@ defmodule SetlistifyWeb.SearchLive do
             ← Prev
           </span>
         <% end %>
-        
-    <!-- Page Numbers -->
+
+        <%!-- Page Numbers --%>
         <div class="flex items-center gap-4">
           {render_page_numbers(assigns)}
         </div>
-        
-    <!-- Next -->
+
+        <%!-- Next --%>
         <%= if @page < @total_pages do %>
           <.link
             navigate={build_pagination_url(@query, @page + 1)}


### PR DESCRIPTION
Closes #154

## Summary

- Replaced 5 HTML comments (`<!-- -->`) with HEEx comment syntax (`<%!-- --%>`) in `~H` sigil blocks, per the AGENTS.md convention
- Converted 2 comments in `lib/setlistify_web/components/core_components.ex` (inside the `logo/1` component)
- Converted 3 comments in `lib/setlistify_web/live/search_live.ex` (inside the pagination component)
- Ran a full grep of `lib/setlistify_web/**/*.{ex,heex}` — no additional `<!--` patterns were found

## No overlap with PR #123

This branch only touches comment syntax. No `<Layouts.app>` wrapping or layout-related changes were made.

## Test plan

- [x] `mix format` — clean
- [x] `mix test` — 278 tests, 0 failures

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiH8yEJTEaC9kXv2VcQXgz)_