### PR TITLE
fix: add phx-update="ignore" to elements with DOM-managing phx-hook

### DIFF
--- a/lib/setlistify_web/components/core_components.ex
+++ b/lib/setlistify_web/components/core_components.ex
@@ -778,6 +778,7 @@ defmodule SetlistifyWeb.CoreComponents do
         id="rotating-text"
         class={[@computed_text_classes]}
         phx-hook="RotatingText"
+        phx-update="ignore"
         data-texts={JSON.encode!(@texts)}
       >
         <span>{List.first(@texts)}</span>

--- a/lib/setlistify_web/components/layouts/app.html.heex
+++ b/lib/setlistify_web/components/layouts/app.html.heex
@@ -54,6 +54,7 @@
         <button
           id="apple-music-signin"
           phx-hook="AppleMusicAuth"
+          phx-update="ignore"
           data-developer-token={am_token}
           data-redirect-to={@redirect_to || "/"}
           class="flex items-center gap-2 text-white hover:text-pink-400 text-sm sm:text-base whitespace-nowrap"

--- a/lib/setlistify_web/live/setlists/show_live.ex
+++ b/lib/setlistify_web/live/setlists/show_live.ex
@@ -94,6 +94,7 @@ defmodule SetlistifyWeb.Setlists.ShowLive do
                                 class="h-4 w-4 text-gray-400 animate-spin opacity-0"
                                 aria-label="searching for song"
                                 phx-hook="DelayedShow"
+                                phx-update="ignore"
                                 data-delay="250"
                               />
                             </:loading>


### PR DESCRIPTION
Closes #155

## Summary

- Added `phx-update="ignore"` to the `DelayedShow` loading spinner in `show_live.ex` (the primary fix for #155)
- Added `phx-update="ignore"` to the `AppleMusicAuth` sign-in button in `app.html.heex`
- Added `phx-update="ignore"` to the `RotatingText` component in `core_components.ex`

## Other phx-hook usages reviewed

All hooks in the codebase were audited against the AGENTS.md rule: _"anytime you use `phx-hook="MyHook"` and that js hook manages its own DOM, you must also set the `phx-update="ignore"` attribute."_

| Hook | File | Manages DOM? | Had ignore? | Action |
|------|------|-------------|-------------|--------|
| `DelayedShow` | `show_live.ex` | Yes — removes `opacity-0`, adds `opacity-100` | No | Added |
| `AppleMusicAuth` | `app.html.heex` | Yes — mutates button `innerHTML` and `disabled` | No | Added |
| `RotatingText` | `core_components.ex` | Yes — rotates `textContent` and `opacity` via `setInterval` | No | Added |
| `AppleMusicSignOut` | `app.html.heex` | No — only adds a click listener and redirects (`window.location = "/signout"`); does not modify DOM content | N/A | Left alone |

## Test plan

- [x] `mix format` — no changes
- [x] `mix test` — 279 tests, 0 failures