### PR TITLE
docs: document MusicKit CDN script as justified exception (#151)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,12 @@ custom classes must fully style the input
   - You cannot reference an external vendor'd script `src` or link `href` in the layouts
   - You must import the vendor deps into app.js and app.css to use them
   - **Never write inline <script>custom js</script> tags within templates**
+  - **Known exception — Apple MusicKit v3**: Apple does not publish MusicKit as an npm
+    package, and its license header explicitly prohibits copying, modifying, or re-hosting
+    the file. The CDN `<script src="https://js-cdn.music.apple.com/musickit/v3/musickit.js">`
+    tag in `app.html.heex` is the only supported delivery mechanism. It is conditionally
+    injected (see `SetlistifyWeb.Layouts.needs_music_kit?/1`) and is a deliberate, justified
+    exception to the "no external script tags" rule. See issue #151.
 
 ### UI/UX & design guidelines
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ custom classes must fully style the input
     package, and its license header explicitly prohibits copying, modifying, or re-hosting
     the file. The CDN `<script src="https://js-cdn.music.apple.com/musickit/v3/musickit.js">`
     tag in `app.html.heex` is the only supported delivery mechanism. It is conditionally
-    injected (see `SetlistifyWeb.Layouts.needs_music_kit?/1`) and is a deliberate, justified
+    injected (see the private `needs_music_kit?/1` helper in `SetlistifyWeb.Layouts`) and is a deliberate, justified
     exception to the "no external script tags" rule. See issue #151.
 
 ### UI/UX & design guidelines

--- a/lib/setlistify_web/components/layouts/app.html.heex
+++ b/lib/setlistify_web/components/layouts/app.html.heex
@@ -1,3 +1,12 @@
+<%!--
+  MusicKit v3 is intentionally loaded from Apple's CDN — not bundled via esbuild.
+  Apple does not publish MusicKit as an npm package (neither @apple/musickit nor
+  musickit-js exist on npmjs.com), and the SDK license header explicitly prohibits
+  copying, modifying, re-hosting, or creating derivative works of the file.
+  There is no supported alternative to this CDN script tag. Conditionally injected
+  only when Apple Music is enabled (see SetlistifyWeb.Layouts.needs_music_kit?/1).
+  Deliberate exception to the "no external script tags" rule in AGENTS.md. Refs: #151.
+--%>
 <%= if needs_music_kit?(@current_scope.user_session) do %>
   <script async src="https://js-cdn.music.apple.com/musickit/v3/musickit.js">
   </script>


### PR DESCRIPTION
## Summary

Closes #151

This PR documents the result of auditing the Apple MusicKit v3 external `<script>` tag in `app.html.heex` against the AGENTS.md rule that only `app.js` and `app.css` bundles are supported (no external CDN script tags).

**Conclusion: Option B — the CDN tag is a mandatory, justified exception.**

### Investigation findings

1. **No npm package exists.** Both `musickit-js` and `@apple/musickit-js` return HTTP 404 on the npm registry. Apple has never published MusicKit JS as an installable package.

2. **License prohibits self-hosting.** The MusicKit JS file served from `https://js-cdn.music.apple.com/musickit/v3/musickit.js` contains a license header stating:
   > "You may not copy, modify, re-host, or create derivative works of this file"
   Bundling via esbuild would constitute a copy/derivative work and is explicitly prohibited.

3. **Current usage is already minimal.** The script tag is guarded by `needs_music_kit?/1` and is only injected when Apple Music integration is configured — it is never loaded for Spotify-only users.

### Changes

- **`lib/setlistify_web/components/layouts/app.html.heex`** — Added a HEEx comment above the script tag explaining why it is a deliberate CDN exception, referencing this issue.
- **`AGENTS.md`** — Added a "Known exception — Apple MusicKit v3" note under the JS/CSS bundling guidelines so future contributors understand this is intentional and not a mistake to fix.

## Test plan

- [x] `mix test` — 278 tests, 0 failures
- [x] `mix format` — no changes
- [ ] Verify no conflict with PR #123 (that PR changes line 94 `{@inner_content}` → `{render_slot(@inner_block)}`; this PR only touches lines 1–12 of `app.html.heex`)

https://claude.ai/code/session_01HiH8yEJTEaC9kXv2VcQXgz

---
_Generated by [Claude Code](https://claude.ai/code/session_01HiH8yEJTEaC9kXv2VcQXgz)_