### PR TITLE
chore: modernize core_components.ex to Phoenix 1.8 conventions

### DIFF
--- a/lib/setlistify_web/components/core_components.ex
+++ b/lib/setlistify_web/components/core_components.ex
@@ -69,48 +69,6 @@ defmodule SetlistifyWeb.CoreComponents do
   end
 
   @doc """
-  Shows the flash group with standard titles and content.
-
-  ## Examples
-
-      <.flash_group flash={@flash} />
-  """
-  attr :flash, :map, required: true, doc: "the map of flash messages"
-  attr :id, :string, default: "flash-group", doc: "the optional id of flash container"
-
-  def flash_group(assigns) do
-    ~H"""
-    <div id={@id}>
-      <.flash kind={:info} title={gettext("Success!")} flash={@flash} />
-      <.flash kind={:error} title={gettext("Error!")} flash={@flash} />
-      <.flash
-        id="client-error"
-        kind={:error}
-        title={gettext("We can't find the internet")}
-        phx-disconnected={show(".phx-client-error #client-error")}
-        phx-connected={hide("#client-error")}
-        hidden
-      >
-        {gettext("Attempting to reconnect")}
-        <.icon name="hero-arrow-path" class="ml-1 h-3 w-3 animate-spin" />
-      </.flash>
-
-      <.flash
-        id="server-error"
-        kind={:error}
-        title={gettext("Something went wrong!")}
-        phx-disconnected={show(".phx-server-error #server-error")}
-        phx-connected={hide("#server-error")}
-        hidden
-      >
-        {gettext("Hang in there while we get back on track")}
-        <.icon name="hero-arrow-path" class="ml-1 h-3 w-3 animate-spin" />
-      </.flash>
-    </div>
-    """
-  end
-
-  @doc """
   Renders a button.
 
   When `href`, `navigate`, or `patch` is passed, renders a `<.link>` styled as

--- a/lib/setlistify_web/components/core_components.ex
+++ b/lib/setlistify_web/components/core_components.ex
@@ -290,6 +290,9 @@ defmodule SetlistifyWeb.CoreComponents do
   attr :options, :list, doc: "the options to pass to Phoenix.HTML.Form.options_for_select/2"
   attr :multiple, :boolean, default: false, doc: "the multiple flag for select inputs"
 
+  attr :class, :string, default: nil, doc: "the input class to use over defaults"
+  attr :error_class, :string, default: nil
+
   attr :rest, :global, include: ~w(accept autocomplete capture cols disabled form list max maxlength min minlength
                 multiple pattern placeholder readonly required rows size step)
 
@@ -338,7 +341,10 @@ defmodule SetlistifyWeb.CoreComponents do
           name={@name}
           value="true"
           checked={@checked}
-          class="rounded border-gray-700 bg-gray-800 text-emerald-500 focus:ring-emerald-500"
+          class={[
+            @class || "rounded border-gray-700 bg-gray-800 text-emerald-500 focus:ring-emerald-500",
+            @errors != [] && (@error_class || "border-rose-400")
+          ]}
           {@rest}
         /> {@label}
       </label>
@@ -350,11 +356,15 @@ defmodule SetlistifyWeb.CoreComponents do
   def input(%{type: "select"} = assigns) do
     ~H"""
     <div>
-      <.label for={@id}>{@label}</.label>
+      <.label :if={@label} for={@id}>{@label}</.label>
       <select
         id={@id}
         name={@name}
-        class="mt-2 block w-full rounded-lg border border-gray-800 bg-gray-900 text-white focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500 sm:text-sm"
+        class={[
+          @class ||
+            "mt-2 block w-full rounded-lg border border-gray-800 bg-gray-900 text-white focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500 sm:text-sm",
+          @errors != [] && (@error_class || "border-rose-400 focus:border-rose-400")
+        ]}
         multiple={@multiple}
         {@rest}
       >
@@ -369,14 +379,14 @@ defmodule SetlistifyWeb.CoreComponents do
   def input(%{type: "textarea"} = assigns) do
     ~H"""
     <div>
-      <.label for={@id}>{@label}</.label>
+      <.label :if={@label} for={@id}>{@label}</.label>
       <textarea
         id={@id}
         name={@name}
         class={[
-          "mt-2 block w-full rounded-lg bg-gray-900 text-white focus:ring-2 focus:ring-emerald-500 sm:text-sm sm:leading-6 min-h-[6rem]",
-          @errors == [] && "border-gray-800 focus:border-emerald-500",
-          @errors != [] && "border-rose-400 focus:border-rose-400"
+          @class ||
+            "mt-2 block w-full rounded-lg bg-gray-900 text-white focus:ring-2 focus:ring-emerald-500 sm:text-sm sm:leading-6 min-h-[6rem] border-gray-800 focus:border-emerald-500",
+          @errors != [] && (@error_class || "border-rose-400 focus:border-rose-400")
         ]}
         {@rest}
       >{Phoenix.HTML.Form.normalize_value("textarea", @value)}</textarea>
@@ -389,16 +399,16 @@ defmodule SetlistifyWeb.CoreComponents do
   def input(assigns) do
     ~H"""
     <div>
-      <.label for={@id}>{@label}</.label>
+      <.label :if={@label} for={@id}>{@label}</.label>
       <input
         type={@type}
         name={@name}
         id={@id}
         value={Phoenix.HTML.Form.normalize_value(@type, @value)}
         class={[
-          "mt-2 block w-full rounded-lg bg-gray-900 text-white border focus:ring-2 focus:ring-emerald-500 sm:text-sm sm:leading-6",
-          @errors == [] && "border-gray-800 focus:border-emerald-500",
-          @errors != [] && "border-rose-400 focus:border-rose-400"
+          @class ||
+            "mt-2 block w-full rounded-lg bg-gray-900 text-white border border-gray-800 focus:border-emerald-500 focus:ring-2 focus:ring-emerald-500 sm:text-sm sm:leading-6",
+          @errors != [] && (@error_class || "border-rose-400 focus:border-rose-400")
         ]}
         {@rest}
       />

--- a/lib/setlistify_web/components/core_components.ex
+++ b/lib/setlistify_web/components/core_components.ex
@@ -3,7 +3,7 @@ defmodule SetlistifyWeb.CoreComponents do
   Provides core UI components.
 
   At first glance, this module may seem daunting, but its goal is to provide
-  core building blocks for your application, such as modals, tables, and
+  core building blocks for your application, such as tables and
   forms. The components consist mostly of markup and are well-documented
   with doc strings and declarative assigns. You may customize and style
   them in any way you want, based on your application growth and needs.
@@ -163,7 +163,7 @@ defmodule SetlistifyWeb.CoreComponents do
   attr :multiple, :boolean, default: false, doc: "the multiple flag for select inputs"
 
   attr :class, :string, default: nil, doc: "the input class to use over defaults"
-  attr :error_class, :string, default: nil
+  attr :error_class, :string, default: nil, doc: "the error class to apply over the default error classes"
 
   attr :rest, :global, include: ~w(accept autocomplete capture cols disabled form list max maxlength min minlength
                 multiple pattern placeholder readonly required rows size step)

--- a/lib/setlistify_web/components/core_components.ex
+++ b/lib/setlistify_web/components/core_components.ex
@@ -21,76 +21,6 @@ defmodule SetlistifyWeb.CoreComponents do
   alias Phoenix.LiveView.JS
 
   @doc """
-  Renders a modal.
-
-  ## Examples
-
-      <.modal id="confirm-modal">
-        This is a modal.
-      </.modal>
-
-  JS commands may be passed to the `:on_cancel` to configure
-  the closing/cancel event, for example:
-
-      <.modal id="confirm" on_cancel={JS.navigate(~p"/posts")}>
-        This is another modal.
-      </.modal>
-
-  """
-  attr :id, :string, required: true
-  attr :show, :boolean, default: false
-  attr :on_cancel, JS, default: %JS{}
-  slot :inner_block, required: true
-
-  def modal(assigns) do
-    ~H"""
-    <div
-      id={@id}
-      phx-mounted={@show && show_modal(@id)}
-      phx-remove={hide_modal(@id)}
-      data-cancel={JS.exec(@on_cancel, "phx-remove")}
-      class="relative z-50 hidden"
-    >
-      <div id={"#{@id}-bg"} class="bg-black/80 fixed inset-0 transition-opacity" aria-hidden="true" />
-      <div
-        class="fixed inset-0 overflow-y-auto"
-        aria-labelledby={"#{@id}-title"}
-        aria-describedby={"#{@id}-description"}
-        role="dialog"
-        aria-modal="true"
-        tabindex="0"
-      >
-        <div class="flex min-h-full items-center justify-center">
-          <div class="w-full max-w-3xl p-4 sm:p-6 lg:py-8">
-            <.focus_wrap
-              id={"#{@id}-container"}
-              phx-window-keydown={JS.exec("data-cancel", to: "##{@id}")}
-              phx-key="escape"
-              phx-click-away={JS.exec("data-cancel", to: "##{@id}")}
-              class="shadow-emerald-500/10 ring-gray-800 relative hidden rounded-2xl bg-gray-900 p-14 shadow-lg ring-1 transition"
-            >
-              <div class="absolute top-6 right-5">
-                <button
-                  phx-click={JS.exec("data-cancel", to: "##{@id}")}
-                  type="button"
-                  class="-m-3 flex-none p-3 text-gray-400 hover:text-white transition-colors"
-                  aria-label={gettext("close")}
-                >
-                  <.icon name="hero-x-mark-solid" class="h-5 w-5" />
-                </button>
-              </div>
-              <div id={"#{@id}-content"} class="text-white">
-                {render_slot(@inner_block)}
-              </div>
-            </.focus_wrap>
-          </div>
-        </div>
-      </div>
-    </div>
-    """
-  end
-
-  @doc """
   Renders flash notices.
 
   ## Examples
@@ -177,42 +107,6 @@ defmodule SetlistifyWeb.CoreComponents do
         <.icon name="hero-arrow-path" class="ml-1 h-3 w-3 animate-spin" />
       </.flash>
     </div>
-    """
-  end
-
-  @doc """
-  Renders a simple form.
-
-  ## Examples
-
-      <.simple_form for={@form} phx-change="validate" phx-submit="save">
-        <.input field={@form[:email]} label="Email"/>
-        <.input field={@form[:username]} label="Username" />
-        <:actions>
-          <.button>Save</.button>
-        </:actions>
-      </.simple_form>
-  """
-  attr :for, :any, required: true, doc: "the data structure for the form"
-  attr :as, :any, default: nil, doc: "the server side parameter to collect all input under"
-
-  attr :rest, :global,
-    include: ~w(autocomplete name rel action enctype method novalidate target multipart),
-    doc: "the arbitrary HTML attributes to apply to the form tag"
-
-  slot :inner_block, required: true
-  slot :actions, doc: "the slot for form actions, such as a submit button"
-
-  def simple_form(assigns) do
-    ~H"""
-    <.form :let={f} for={@for} as={@as} {@rest}>
-      <div class="space-y-8">
-        {render_slot(@inner_block, f)}
-        <div :for={action <- @actions} class="mt-2 flex items-center justify-between gap-6">
-          {render_slot(action, f)}
-        </div>
-      </div>
-    </.form>
     """
   end
 
@@ -576,29 +470,6 @@ defmodule SetlistifyWeb.CoreComponents do
   end
 
   @doc """
-  Renders a back navigation link.
-
-  ## Examples
-
-      <.back navigate={~p"/posts"}>Back to posts</.back>
-  """
-  attr :navigate, :any, required: true
-  slot :inner_block, required: true
-
-  def back(assigns) do
-    ~H"""
-    <div class="mt-16">
-      <.link
-        navigate={@navigate}
-        class="text-sm font-semibold leading-6 text-emerald-400 hover:text-emerald-300 transition-colors"
-      >
-        <.icon name="hero-arrow-left-solid" class="h-3 w-3" /> {render_slot(@inner_block)}
-      </.link>
-    </div>
-    """
-  end
-
-  @doc """
   Renders a [Heroicon](https://heroicons.com).
 
   Heroicons come in three styles – outline, solid, and mini.
@@ -646,31 +517,6 @@ defmodule SetlistifyWeb.CoreComponents do
         {"transition-all ease-in duration-200", "opacity-100 translate-y-0 sm:scale-100",
          "opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"}
     )
-  end
-
-  def show_modal(js \\ %JS{}, id) when is_binary(id) do
-    js
-    |> JS.show(to: "##{id}")
-    |> JS.show(
-      to: "##{id}-bg",
-      time: 300,
-      transition: {"transition-all ease-out duration-300", "opacity-0", "opacity-100"}
-    )
-    |> show("##{id}-container")
-    |> JS.add_class("overflow-hidden", to: "body")
-    |> JS.focus_first(to: "##{id}-content")
-  end
-
-  def hide_modal(js \\ %JS{}, id) do
-    js
-    |> JS.hide(
-      to: "##{id}-bg",
-      transition: {"transition-all ease-in duration-200", "opacity-100", "opacity-0"}
-    )
-    |> hide("##{id}-container")
-    |> JS.hide(to: "##{id}", transition: {"block", "block", "hidden"})
-    |> JS.remove_class("overflow-hidden", to: "body")
-    |> JS.pop_focus()
   end
 
   @doc """

--- a/lib/setlistify_web/components/core_components.ex
+++ b/lib/setlistify_web/components/core_components.ex
@@ -113,31 +113,51 @@ defmodule SetlistifyWeb.CoreComponents do
   @doc """
   Renders a button.
 
+  When `href`, `navigate`, or `patch` is passed, renders a `<.link>` styled as
+  a button. Otherwise renders a `<button>` element.
+
   ## Examples
 
       <.button>Send!</.button>
       <.button phx-click="go" class="ml-2">Send!</.button>
+      <.button navigate={~p"/playlists"}>View Playlists</.button>
   """
   attr :type, :string, default: nil
   attr :class, :string, default: nil
-  attr :rest, :global, include: ~w(disabled form name value)
+  attr :rest, :global, include: ~w(href navigate patch method download disabled form name value)
 
   slot :inner_block, required: true
 
-  def button(assigns) do
-    ~H"""
-    <button
-      type={@type}
-      class={[
-        "phx-submit-loading:opacity-75 rounded-full bg-emerald-500 hover:bg-emerald-400 px-8 py-3",
-        "text-base font-semibold text-black transition-colors",
-        @class
-      ]}
-      {@rest}
-    >
-      {render_slot(@inner_block)}
-    </button>
-    """
+  def button(%{rest: rest} = assigns) do
+    if rest[:href] || rest[:navigate] || rest[:patch] do
+      ~H"""
+      <.link
+        class={[
+          "phx-submit-loading:opacity-75 inline-flex items-center justify-center rounded-full",
+          "bg-emerald-500 hover:bg-emerald-400 px-8 py-3",
+          "text-base font-semibold text-black transition-colors",
+          @class
+        ]}
+        {@rest}
+      >
+        {render_slot(@inner_block)}
+      </.link>
+      """
+    else
+      ~H"""
+      <button
+        type={@type}
+        class={[
+          "phx-submit-loading:opacity-75 rounded-full bg-emerald-500 hover:bg-emerald-400 px-8 py-3",
+          "text-base font-semibold text-black transition-colors",
+          @class
+        ]}
+        {@rest}
+      >
+        {render_slot(@inner_block)}
+      </button>
+      """
+    end
   end
 
   @doc """

--- a/lib/setlistify_web/components/layouts.ex
+++ b/lib/setlistify_web/components/layouts.ex
@@ -40,4 +40,46 @@ defmodule SetlistifyWeb.Layouts do
   catch
     :exit, _ -> nil
   end
+
+  @doc """
+  Shows the flash group with standard titles and content.
+
+  ## Examples
+
+      <.flash_group flash={@flash} />
+  """
+  attr :flash, :map, required: true, doc: "the map of flash messages"
+  attr :id, :string, default: "flash-group", doc: "the optional id of flash container"
+
+  def flash_group(assigns) do
+    ~H"""
+    <div id={@id}>
+      <.flash kind={:info} title={gettext("Success!")} flash={@flash} />
+      <.flash kind={:error} title={gettext("Error!")} flash={@flash} />
+      <.flash
+        id="client-error"
+        kind={:error}
+        title={gettext("We can't find the internet")}
+        phx-disconnected={show(".phx-client-error #client-error")}
+        phx-connected={hide("#client-error")}
+        hidden
+      >
+        {gettext("Attempting to reconnect")}
+        <.icon name="hero-arrow-path" class="ml-1 h-3 w-3 animate-spin" />
+      </.flash>
+
+      <.flash
+        id="server-error"
+        kind={:error}
+        title={gettext("Something went wrong!")}
+        phx-disconnected={show(".phx-server-error #server-error")}
+        phx-connected={hide("#server-error")}
+        hidden
+      >
+        {gettext("Hang in there while we get back on track")}
+        <.icon name="hero-arrow-path" class="ml-1 h-3 w-3 animate-spin" />
+      </.flash>
+    </div>
+    """
+  end
 end

--- a/lib/setlistify_web/components/layouts.ex
+++ b/lib/setlistify_web/components/layouts.ex
@@ -9,6 +9,7 @@ defmodule SetlistifyWeb.Layouts do
   `use SetlistifyWeb, :live_view`.
   """
   use SetlistifyWeb, :html
+  use Gettext, backend: SetlistifyWeb.Gettext
 
   alias Setlistify.Scope
   alias Setlistify.Spotify.UserSession


### PR DESCRIPTION
## Summary

Four commits that bring `core_components.ex` (and `layouts.ex`) in line with Phoenix 1.8 conventions and our AGENTS.md guidelines.

---

### Commit 1 — adopt modern `<.input>` class-override pattern (`63c2481`)

- Moves `class` and `error_class` out of `:global` (rest attrs) and declares them as explicit `attr` declarations on `input/1`, so Phoenix sees them as first-class assigns rather than HTML pass-throughs.
- Renders each input's class list as `[@class || "default classes here", @errors != [] && (@error_class || "error classes here")]` — when a caller passes `class=`, the default string is never emitted, so no Tailwind utility conflicts arise. This is the behaviour AGENTS.md already documents: "If you override the default input classes, no default classes are inherited."
- Guards every `<.label>` with `:if={@label}` so no empty `` element is emitted when no label is passed.
- All existing pure-Tailwind default class strings are preserved exactly — they are simply placed behind the `@class ||` guard.

Refs #150

---

### Commit 2 — drop unused helpers (`6833959`)

Removes five dead-code functions that are only referenced in their own docstring examples with no callers outside `core_components.ex`. The fresh Phoenix 1.8 generator template has also dropped them:

- `modal/1` + its `attr`/`slot` declarations
- `show_modal/1,2` (JS helper)
- `hide_modal/1,2` (JS helper)
- `simple_form/1` (we use `<.form>` directly)
- `back/1` (we use `<.link>` directly)

---

### Commit 3 — add navigation support to `<.button>` (`84654fd`)

When `href`, `navigate`, or `patch` is present, `<.button>` now renders a `<.link>` styled identically to the `<button>` branch (same pill shape, emerald colours, font weight). This lets call sites use `<.button navigate={...}>` instead of copy-pasting the pill classes onto a bare `<.link>`.

The link branch adds `inline-flex items-center justify-center` so the anchor element lays out like a button. No `:variant` attr added — we only have one style today.

---

### Commit 4 — move `flash_group` from CoreComponents to Layouts (`acc1d73`)

Resolves #168.

AGENTS.md states: _"Phoenix v1.8 moved the `<.flash_group>` component to the `Layouts` module. You are **forbidden** from calling `<.flash_group>` outside of the `layouts.ex` module."_

- Cuts `flash_group/1` from `core_components.ex`.
- Pastes it into `layouts.ex` (near the end of the module, away from PR #123's `app/1` changes).
- `app.html.heex` is unchanged — `<.flash_group flash={@flash} />` now resolves to `Layouts.flash_group/1` because the template is embedded into `Layouts` via `embed_templates`. The function body calls `<.flash>` and `<.icon>` which are available via the `CoreComponents` import that `Layouts` inherits through `use SetlistifyWeb, :html`.

---

## Test plan

- [x] `mix compile --warnings-as-errors` passes with no warnings
- [x] `mix test` — 278 tests, 0 failures
- [x] `mix format` applied after each commit

https://claude.ai/code/session_01HiH8yEJTEaC9kXv2VcQXgz