### PR TITLE
chore: exponential backoff + telemetry for Apple Music token retry

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -69,10 +69,12 @@ config :setlistify, SetlistifyWeb.Endpoint,
     ]
   ]
 
-# Aggressive retry interval for DeveloperTokenManager in dev so a misconfigured
-# Apple Music PEM surfaces quickly. Prod uses the 5-minute default baked into
-# the module.
-config :setlistify, apple_music_retry_interval_ms: 30 * 1_000
+# Aggressive backoff schedule for DeveloperTokenManager in dev so a misconfigured
+# Apple Music PEM surfaces quickly and keeps surfacing. Prod uses the module defaults
+# (30s base → 15m cap).
+config :setlistify, apple_music_retry_base_ms: 30 * 1_000
+config :setlistify, apple_music_retry_max_ms: 60 * 1_000
+config :setlistify, apple_music_retry_multiplier: 2
 
 # Enable dev routes for dashboard and mailbox
 config :setlistify, dev_routes: true

--- a/lib/setlistify/apple_music/developer_token_manager.ex
+++ b/lib/setlistify/apple_music/developer_token_manager.ex
@@ -24,15 +24,24 @@ defmodule Setlistify.AppleMusic.DeveloperTokenManager do
   If token generation fails (misconfigured PEM, missing env vars, etc.) the process
   does **not** crash. It logs a stacktraced error plus a human-readable banner
   ("Apple Music sign-in is DISABLED"), keeps `token: nil` in state, and schedules
-  a periodic retry. Callers receive `nil` from `get_token/0` (the layout's existing
-  guard hides the sign-in UI). The retry keeps the failure surfacing in logs so a
-  silent launch with bad config is hard to miss, and self-heals if the config is
-  fixed via `Application.put_env` in a running node. Once the operator restarts
-  with corrected config, normal operation resumes.
+  a retry on an exponential backoff (base 30s, capped at 15m by default). Callers
+  receive `nil` from `get_token/0` (the layout's existing guard hides the sign-in
+  UI). The backoff means a long-lived misconfig produces a handful of stacktraces
+  per hour rather than one every 5 minutes, while still surfacing the failure
+  promptly when it first occurs. The schedule resets to the base interval on
+  successful recovery or on `regenerate_token/0`.
 
   If the cached token's `expires_at` passes while the manager is stuck retrying
   (e.g. signing has been broken for the token's whole 30-day lifetime),
   `get_token/0` returns `nil` rather than handing back an expired binary.
+
+  ## Telemetry
+
+  Each attempt emits `[:setlistify, :apple_music, :developer_token, :attempt]`
+  with measurements `%{count: 1, healthy: 1 | 0}` and metadata
+  `%{phase: :generate | :refresh | :regenerate | :retry, outcome: :ok | :error}`.
+  `Setlistify.PromEx.Plugins.AppleMusic` derives a counter (by phase × outcome)
+  and a "last attempt healthy" gauge from this event.
   """
 
   use GenServer
@@ -47,16 +56,31 @@ defmodule Setlistify.AppleMusic.DeveloperTokenManager do
             token: String.t() | nil,
             expires_at: integer() | nil,
             timer_ref: reference() | nil,
-            retry_interval_ms: pos_integer()
+            retry_base_ms: pos_integer(),
+            retry_max_ms: pos_integer(),
+            retry_multiplier: pos_integer(),
+            current_retry_ms: pos_integer()
           }
 
-    @enforce_keys [:retry_interval_ms]
-    defstruct [:token, :expires_at, :timer_ref, :retry_interval_ms]
+    @enforce_keys [:retry_base_ms, :retry_max_ms, :retry_multiplier, :current_retry_ms]
+    defstruct [
+      :token,
+      :expires_at,
+      :timer_ref,
+      :retry_base_ms,
+      :retry_max_ms,
+      :retry_multiplier,
+      :current_retry_ms
+    ]
   end
+
+  @telemetry_event [:setlistify, :apple_music, :developer_token, :attempt]
 
   @refresh_threshold 5 * 60
   @default_ttl_seconds 30 * 24 * 60 * 60
-  @default_retry_interval_ms 5 * 60 * 1_000
+  @default_retry_base_ms 30 * 1_000
+  @default_retry_max_ms 15 * 60 * 1_000
+  @default_retry_multiplier 2
 
   def start_link(opts), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
 
@@ -68,33 +92,60 @@ defmodule Setlistify.AppleMusic.DeveloperTokenManager do
   Called on a 401 response from ExternalClient. Cancels the pending scheduled
   refresh and reschedules from the new expiry to prevent a double refresh.
 
-  Returns the existing cached token (which may be `nil` in degraded mode) if
-  regeneration fails.
+  Resets the retry backoff to its base interval regardless of outcome — an
+  operator-initiated call deserves a fresh schedule. Returns the existing cached
+  token (which may be `nil` in degraded mode) if regeneration fails.
   """
   def regenerate_token, do: GenServer.call(__MODULE__, :regenerate_token)
 
-  def init(opts) do
-    default =
-      Application.get_env(
-        :setlistify,
-        :apple_music_retry_interval_ms,
-        @default_retry_interval_ms
-      )
+  @doc "The telemetry event name emitted on each token attempt."
+  def telemetry_event, do: @telemetry_event
 
-    retry_interval_ms = Keyword.get(opts, :retry_interval_ms, default)
-    {:ok, %State{retry_interval_ms: retry_interval_ms}, {:continue, :generate_token}}
+  def init(opts) do
+    retry_base_ms = retry_opt(opts, :retry_base_ms, :apple_music_retry_base_ms, @default_retry_base_ms)
+    retry_max_ms = retry_opt(opts, :retry_max_ms, :apple_music_retry_max_ms, @default_retry_max_ms)
+
+    retry_multiplier =
+      retry_opt(opts, :retry_multiplier, :apple_music_retry_multiplier, @default_retry_multiplier)
+
+    state = %State{
+      retry_base_ms: retry_base_ms,
+      retry_max_ms: retry_max_ms,
+      retry_multiplier: retry_multiplier,
+      current_retry_ms: retry_base_ms
+    }
+
+    {:ok, state, {:continue, :generate_token}}
   end
 
   def handle_continue(:generate_token, %State{} = state) do
     case generate_and_sign() do
       {:ok, token, expires_at} ->
+        emit_attempt(:generate, :ok)
         timer_ref = schedule_refresh(expires_at, state.timer_ref)
-        {:noreply, %{state | token: token, expires_at: expires_at, timer_ref: timer_ref}}
+
+        {:noreply,
+         %{
+           state
+           | token: token,
+             expires_at: expires_at,
+             timer_ref: timer_ref,
+             current_retry_ms: state.retry_base_ms
+         }}
 
       {:error, reason} ->
         log_token_error(:generate, reason)
-        timer_ref = schedule_retry(state)
-        {:noreply, %{state | token: nil, expires_at: nil, timer_ref: timer_ref}}
+        emit_attempt(:generate, :error)
+        {timer_ref, next_retry_ms} = schedule_retry(state)
+
+        {:noreply,
+         %{
+           state
+           | token: nil,
+             expires_at: nil,
+             timer_ref: timer_ref,
+             current_retry_ms: next_retry_ms
+         }}
     end
   end
 
@@ -107,14 +158,17 @@ defmodule Setlistify.AppleMusic.DeveloperTokenManager do
   end
 
   def handle_call(:regenerate_token, _from, %State{} = state) do
+    state = %{state | current_retry_ms: state.retry_base_ms}
+
     case generate_and_sign() do
       {:ok, token, expires_at} ->
+        emit_attempt(:regenerate, :ok)
         timer_ref = schedule_refresh(expires_at, state.timer_ref)
-        new_state = %{state | token: token, expires_at: expires_at, timer_ref: timer_ref}
-        {:reply, token, new_state}
+        {:reply, token, %{state | token: token, expires_at: expires_at, timer_ref: timer_ref}}
 
       {:error, reason} ->
         log_token_error(:regenerate, reason)
+        emit_attempt(:regenerate, :error)
         {:reply, state.token, state}
     end
   end
@@ -122,13 +176,23 @@ defmodule Setlistify.AppleMusic.DeveloperTokenManager do
   def handle_info(:refresh_token, %State{} = state) do
     case generate_and_sign() do
       {:ok, token, expires_at} ->
+        emit_attempt(:refresh, :ok)
         timer_ref = schedule_refresh(expires_at, state.timer_ref)
-        {:noreply, %{state | token: token, expires_at: expires_at, timer_ref: timer_ref}}
+
+        {:noreply,
+         %{
+           state
+           | token: token,
+             expires_at: expires_at,
+             timer_ref: timer_ref,
+             current_retry_ms: state.retry_base_ms
+         }}
 
       {:error, reason} ->
         log_token_error(:refresh, reason)
-        timer_ref = schedule_retry(state)
-        {:noreply, %{state | timer_ref: timer_ref}}
+        emit_attempt(:refresh, :error)
+        {timer_ref, next_retry_ms} = schedule_retry(state)
+        {:noreply, %{state | timer_ref: timer_ref, current_retry_ms: next_retry_ms}}
     end
   end
 
@@ -136,13 +200,23 @@ defmodule Setlistify.AppleMusic.DeveloperTokenManager do
     case generate_and_sign() do
       {:ok, token, expires_at} ->
         Logger.info("Apple Music developer token recovered after earlier failure")
+        emit_attempt(:retry, :ok)
         timer_ref = schedule_refresh(expires_at, state.timer_ref)
-        {:noreply, %{state | token: token, expires_at: expires_at, timer_ref: timer_ref}}
+
+        {:noreply,
+         %{
+           state
+           | token: token,
+             expires_at: expires_at,
+             timer_ref: timer_ref,
+             current_retry_ms: state.retry_base_ms
+         }}
 
       {:error, reason} ->
         log_token_error(:retry, reason)
-        timer_ref = schedule_retry(state)
-        {:noreply, %{state | timer_ref: timer_ref}}
+        emit_attempt(:retry, :error)
+        {timer_ref, next_retry_ms} = schedule_retry(state)
+        {:noreply, %{state | timer_ref: timer_ref, current_retry_ms: next_retry_ms}}
     end
   end
 
@@ -176,14 +250,26 @@ defmodule Setlistify.AppleMusic.DeveloperTokenManager do
     """)
   end
 
+  defp emit_attempt(phase, outcome)
+       when phase in [:generate, :refresh, :regenerate, :retry] and outcome in [:ok, :error] do
+    healthy = if outcome == :ok, do: 1, else: 0
+    :telemetry.execute(@telemetry_event, %{count: 1, healthy: healthy}, %{phase: phase, outcome: outcome})
+  end
+
   defp schedule_refresh(expires_at, existing_timer) do
     if existing_timer, do: Process.cancel_timer(existing_timer)
     ms = max((expires_at - System.system_time(:second) - @refresh_threshold) * 1_000, 0)
     Process.send_after(self(), :refresh_token, ms)
   end
 
-  defp schedule_retry(%State{timer_ref: existing_timer, retry_interval_ms: ms}) do
-    if existing_timer, do: Process.cancel_timer(existing_timer)
-    Process.send_after(self(), :retry_generate, ms)
+  defp schedule_retry(%State{} = state) do
+    if state.timer_ref, do: Process.cancel_timer(state.timer_ref)
+    timer_ref = Process.send_after(self(), :retry_generate, state.current_retry_ms)
+    next_ms = min(state.current_retry_ms * state.retry_multiplier, state.retry_max_ms)
+    {timer_ref, next_ms}
+  end
+
+  defp retry_opt(opts, opt_key, app_env_key, default) do
+    Keyword.get(opts, opt_key, Application.get_env(:setlistify, app_env_key, default))
   end
 end

--- a/lib/setlistify/prom_ex.ex
+++ b/lib/setlistify/prom_ex.ex
@@ -13,10 +13,8 @@ defmodule Setlistify.PromEx do
       {Plugins.Phoenix, endpoint: SetlistifyWeb.Endpoint, router: SetlistifyWeb.Router},
       {Plugins.PhoenixLiveView, router: SetlistifyWeb.Router},
       {Plugins.PlugCowboy, routers: [SetlistifyWeb.Router]},
-      {Plugins.PlugRouter, routers: [SetlistifyWeb.Router], event_prefix: [:phoenix, :router_dispatch]}
-
-      # Add your own custom plugins here
-      # Setlistify.PromEx.Plugins.CustomPlugin
+      {Plugins.PlugRouter, routers: [SetlistifyWeb.Router], event_prefix: [:phoenix, :router_dispatch]},
+      Setlistify.PromEx.Plugins.AppleMusic
     ]
   end
 

--- a/lib/setlistify/prom_ex/plugins/apple_music.ex
+++ b/lib/setlistify/prom_ex/plugins/apple_music.ex
@@ -1,0 +1,40 @@
+defmodule Setlistify.PromEx.Plugins.AppleMusic do
+  @moduledoc """
+  PromEx plugin for Apple Music developer token health.
+
+  Surfaces metrics derived from the `[:setlistify, :apple_music, :developer_token, :attempt]`
+  event emitted by `Setlistify.AppleMusic.DeveloperTokenManager`:
+
+  - Counter of attempts tagged by `phase` (`:generate | :refresh | :regenerate | :retry`)
+    and `outcome` (`:ok | :error`)
+  - Gauge that reflects the most recent attempt's health (`1` healthy, `0` degraded)
+    so Grafana can alert on sustained degradation
+  """
+
+  use PromEx.Plugin
+
+  @event [:setlistify, :apple_music, :developer_token, :attempt]
+  @metric_prefix [:setlistify, :apple_music, :developer_token]
+
+  @impl true
+  def event_metrics(_opts) do
+    Event.build(
+      :setlistify_apple_music_developer_token_event_metrics,
+      [
+        counter(
+          @metric_prefix ++ [:attempt, :total],
+          event_name: @event,
+          measurement: :count,
+          description: "Total Apple Music developer token attempts by phase and outcome.",
+          tags: [:phase, :outcome]
+        ),
+        last_value(
+          @metric_prefix ++ [:healthy, :status],
+          event_name: @event,
+          measurement: :healthy,
+          description: "1 when the most recent token attempt succeeded, 0 when it failed."
+        )
+      ]
+    )
+  end
+end

--- a/test/setlistify/apple_music/developer_token_manager_test.exs
+++ b/test/setlistify/apple_music/developer_token_manager_test.exs
@@ -69,7 +69,7 @@ defmodule Setlistify.AppleMusic.DeveloperTokenManagerTest do
 
     test "stays alive with get_token/0 returning nil instead of crashing" do
       capture_log(fn ->
-        start_supervised!({DeveloperTokenManager, retry_interval_ms: 60_000})
+        start_supervised!({DeveloperTokenManager, retry_base_ms: 60_000})
         :sys.get_state(DeveloperTokenManager)
       end)
 
@@ -82,7 +82,7 @@ defmodule Setlistify.AppleMusic.DeveloperTokenManagerTest do
     test "logs a stacktraced error identifying the failure step" do
       log =
         capture_log(fn ->
-          start_supervised!({DeveloperTokenManager, retry_interval_ms: 60_000})
+          start_supervised!({DeveloperTokenManager, retry_base_ms: 60_000})
           :sys.get_state(DeveloperTokenManager)
         end)
 
@@ -94,7 +94,7 @@ defmodule Setlistify.AppleMusic.DeveloperTokenManagerTest do
     test "logs a human-readable 'Apple Music sign-in is DISABLED' banner" do
       log =
         capture_log(fn ->
-          start_supervised!({DeveloperTokenManager, retry_interval_ms: 60_000})
+          start_supervised!({DeveloperTokenManager, retry_base_ms: 60_000})
           :sys.get_state(DeveloperTokenManager)
         end)
 
@@ -105,8 +105,9 @@ defmodule Setlistify.AppleMusic.DeveloperTokenManagerTest do
     test "retries on the configured interval and re-logs the banner on continued failure" do
       log =
         capture_log(fn ->
-          start_supervised!({DeveloperTokenManager, retry_interval_ms: 10})
-          Process.sleep(100)
+          start_supervised!({DeveloperTokenManager, retry_base_ms: 10, retry_max_ms: 50, retry_multiplier: 2})
+
+          Process.sleep(150)
           :sys.get_state(DeveloperTokenManager)
         end)
 
@@ -122,7 +123,7 @@ defmodule Setlistify.AppleMusic.DeveloperTokenManagerTest do
 
     test "recovers via regenerate_token/0 once the configured PEM is valid" do
       capture_log(fn ->
-        start_supervised!({DeveloperTokenManager, retry_interval_ms: 60_000})
+        start_supervised!({DeveloperTokenManager, retry_base_ms: 60_000})
         :sys.get_state(DeveloperTokenManager)
       end)
 
@@ -137,7 +138,7 @@ defmodule Setlistify.AppleMusic.DeveloperTokenManagerTest do
 
     test "recovers via the periodic retry once the configured PEM is valid" do
       capture_log(fn ->
-        start_supervised!({DeveloperTokenManager, retry_interval_ms: 10})
+        start_supervised!({DeveloperTokenManager, retry_base_ms: 10})
         :sys.get_state(DeveloperTokenManager)
       end)
 
@@ -149,6 +150,155 @@ defmodule Setlistify.AppleMusic.DeveloperTokenManagerTest do
 
       token = DeveloperTokenManager.get_token()
       assert is_binary(token)
+    end
+  end
+
+  describe "retry backoff schedule" do
+    setup do
+      Application.put_env(:setlistify, :apple_music_private_key, "not-a-pem")
+      :ok
+    end
+
+    test "current_retry_ms grows by the multiplier on each failure, capped at max_ms" do
+      capture_log(fn ->
+        start_supervised!({DeveloperTokenManager, retry_base_ms: 10_000, retry_max_ms: 40_000, retry_multiplier: 2})
+
+        :sys.get_state(DeveloperTokenManager)
+      end)
+
+      # First failure happened during init/continue. The *next* retry interval
+      # was advanced to base * multiplier = 20_000.
+      assert state().current_retry_ms == 20_000
+
+      drive_retry()
+      assert state().current_retry_ms == 40_000
+
+      drive_retry()
+      # Capped at max_ms instead of doubling to 80_000.
+      assert state().current_retry_ms == 40_000
+
+      drive_retry()
+      assert state().current_retry_ms == 40_000
+    end
+
+    test "current_retry_ms resets to retry_base_ms after a successful recovery" do
+      capture_log(fn ->
+        start_supervised!({DeveloperTokenManager, retry_base_ms: 5_000, retry_max_ms: 60_000, retry_multiplier: 4})
+
+        :sys.get_state(DeveloperTokenManager)
+      end)
+
+      drive_retry()
+      drive_retry()
+      assert state().current_retry_ms > 5_000
+
+      Application.put_env(:setlistify, :apple_music_private_key, @test_private_pem)
+      drive_retry()
+
+      assert state().current_retry_ms == 5_000
+    end
+
+    test "regenerate_token/0 resets the backoff even when regeneration fails" do
+      capture_log(fn ->
+        start_supervised!({DeveloperTokenManager, retry_base_ms: 5_000, retry_max_ms: 60_000, retry_multiplier: 4})
+
+        :sys.get_state(DeveloperTokenManager)
+      end)
+
+      drive_retry()
+      drive_retry()
+      grown = state().current_retry_ms
+      assert grown > 5_000
+
+      capture_log(fn -> DeveloperTokenManager.regenerate_token() end)
+
+      # Reset to the base interval so the next scheduled retry starts fresh.
+      assert state().current_retry_ms == 5_000
+    end
+
+    defp drive_retry do
+      capture_log(fn ->
+        send(Process.whereis(DeveloperTokenManager), :retry_generate)
+        :sys.get_state(DeveloperTokenManager)
+      end)
+    end
+
+    defp state, do: :sys.get_state(DeveloperTokenManager)
+  end
+
+  describe "telemetry" do
+    setup do
+      handler_id = {__MODULE__, self()}
+      test_pid = self()
+
+      :telemetry.attach(
+        handler_id,
+        DeveloperTokenManager.telemetry_event(),
+        fn event, measurements, metadata, _config ->
+          send(test_pid, {:telemetry, event, measurements, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+      :ok
+    end
+
+    test "emits :ok event with phase: :generate on a healthy startup" do
+      start_supervised!(DeveloperTokenManager)
+
+      assert_receive {:telemetry, [:setlistify, :apple_music, :developer_token, :attempt], %{count: 1, healthy: 1},
+                      %{phase: :generate, outcome: :ok}}
+    end
+
+    test "emits :error event with phase: :generate when the PEM is invalid" do
+      Application.put_env(:setlistify, :apple_music_private_key, "not-a-pem")
+
+      capture_log(fn ->
+        start_supervised!({DeveloperTokenManager, retry_base_ms: 60_000})
+        :sys.get_state(DeveloperTokenManager)
+      end)
+
+      assert_receive {:telemetry, [:setlistify, :apple_music, :developer_token, :attempt], %{count: 1, healthy: 0},
+                      %{phase: :generate, outcome: :error}}
+    end
+
+    test "emits phase: :regenerate when regenerate_token/0 is called" do
+      start_supervised!(DeveloperTokenManager)
+      # Drain the startup :generate event so the :regenerate assertion can't pick it up.
+      assert_receive {:telemetry, _, _, %{phase: :generate}}
+
+      DeveloperTokenManager.regenerate_token()
+
+      assert_receive {:telemetry, _, %{healthy: 1}, %{phase: :regenerate, outcome: :ok}}
+    end
+
+    test "emits phase: :refresh when the scheduled refresh fires" do
+      start_supervised!(DeveloperTokenManager)
+      assert_receive {:telemetry, _, _, %{phase: :generate}}
+
+      send(Process.whereis(DeveloperTokenManager), :refresh_token)
+      :sys.get_state(DeveloperTokenManager)
+
+      assert_receive {:telemetry, _, %{healthy: 1}, %{phase: :refresh, outcome: :ok}}
+    end
+
+    test "emits phase: :retry when the retry timer fires" do
+      Application.put_env(:setlistify, :apple_music_private_key, "not-a-pem")
+
+      capture_log(fn ->
+        start_supervised!({DeveloperTokenManager, retry_base_ms: 60_000})
+        :sys.get_state(DeveloperTokenManager)
+      end)
+
+      assert_receive {:telemetry, _, _, %{phase: :generate, outcome: :error}}
+
+      capture_log(fn ->
+        send(Process.whereis(DeveloperTokenManager), :retry_generate)
+        :sys.get_state(DeveloperTokenManager)
+      end)
+
+      assert_receive {:telemetry, _, %{healthy: 0}, %{phase: :retry, outcome: :error}}
     end
   end
 end


### PR DESCRIPTION
## Summary

- `DeveloperTokenManager` retry now uses exponential backoff (`retry_base_ms` → `retry_max_ms` × `retry_multiplier`) instead of a fixed interval. Defaults: **30s base → 15m cap × 2**. Schedule resets to the base on successful generation/refresh/retry and on every `regenerate_token/0` call (success or failure).
- Each attempt emits `[:setlistify, :apple_music, :developer_token, :attempt]` with `%{count: 1, healthy: 0|1}` measurements and `%{phase: :generate | :refresh | :regenerate | :retry, outcome: :ok | :error}` metadata.
- New `Setlistify.PromEx.Plugins.AppleMusic` exposes:
  - `setlistify_apple_music_developer_token_attempt_total{phase, outcome}` (counter)
  - `setlistify_apple_music_developer_token_healthy_status` (gauge: last attempt's health, alertable on sustained `0`)
- Dev config replaces `apple_music_retry_interval_ms` with the new base/max/multiplier knobs (still aggressive: 30s base, 60s cap so a bad PEM keeps surfacing quickly in iex).

Closes #157

## Manual review guidance

The trickiest piece is the backoff state machine — worth a careful read at:

- **`lib/setlistify/apple_music/developer_token_manager.ex`**
  - `handle_continue/2`, `handle_call(:regenerate_token, ...)`, `handle_info(:refresh_token, ...)`, `handle_info(:retry_generate, ...)` — confirm each success path resets `current_retry_ms` to `retry_base_ms`, and each error path advances it via `schedule_retry/1`.
  - `schedule_retry/1` returns `{timer_ref, next_ms}` where `next_ms = min(current * multiplier, max)`. The current attempt uses the *current* value before advancing — i.e. the very first failure uses `retry_base_ms`, the second uses `base * multiplier`, etc.
  - `handle_call(:regenerate_token, ...)` resets `current_retry_ms` *before* attempting, so both the success and error paths leave it at base. On failure it does **not** cancel/reschedule the pending retry timer — the existing timer fires whenever it was originally scheduled, but uses the reset value when it scheduling the *next* one. Confirm that's the semantics you want; if you'd rather have regenerate also reset the in-flight timer to fire after `base_ms` from now, that's a small additional change.
  - `emit_attempt/2` measurements include `healthy: 1 | 0` so a single event powers both the counter and the gauge. If you'd prefer two separate events (one for counts, one for health), say the word.

- **`lib/setlistify/prom_ex/plugins/apple_music.ex`** — small. Worth eyeballing the metric names; once these ship to Grafana Cloud they're effectively load-bearing.

- **`config/dev.exs`** — the dev cap is `60_000` (1 min). This is intentionally tight so iex sessions with a bad PEM keep hammering the banner every minute; let me know if you'd rather match prod's looser schedule.

- **`test/setlistify/apple_music/developer_token_manager_test.exs`**
  - The new `retry backoff schedule` describe drives retries synchronously via `send(pid, :retry_generate)` rather than relying on wall-clock timers — fast and deterministic.
  - The `telemetry` describe attaches a per-test handler and asserts the event shape. Note the "drain :generate event" calls before checking later phases — without those, `assert_receive` would pick up the startup event by accident.

## Test plan

- [x] `mix test` — 286 tests, 0 failures
- [x] `mix credo --strict` — clean
- [x] `mix format` — clean
- [ ] Reviewer: skim the state-machine paths above to confirm reset/advance semantics match the spec in #157
- [ ] Reviewer: confirm PromEx metric names before they reach Grafana Cloud
- [ ] (Out of scope, follow-up) Grafana dashboard panel + alert rule for `setlistify_apple_music_developer_token_healthy_status == 0 for N minutes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)