### PR TITLE
fix: correct invalid puppeteer MCP permission rule

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -40,7 +40,7 @@
       "WebFetch(domain:hex.pm)",
       "mcp__Context7__get-library-docs",
       "mcp__Context7__resolve-library-id",
-      "mcp__puppeteer*",
+      "mcp__puppeteer__*",
       "mcp__tidewave__get_logs"
     ],
     "deny": []


### PR DESCRIPTION
## What

`/doctor` flagged an invalid permission rule in `.claude/settings.json`:

> Invalid permission rule "mcp__puppeteer*" was skipped: Wildcard tool name "mcp__puppeteer*" is not supported in allow rules.

Wildcards aren't supported at the server-name position in **allow** rules — the pattern must include the full `mcp__<server>__` literal prefix, with a glob permitted only in the tool position after it.

This changes `"mcp__puppeteer*"` → `"mcp__puppeteer__*"`, which preserves the original intent (allow all tools from the puppeteer MCP server) in the supported format. The puppeteer server's tools are all named `mcp__puppeteer__puppeteer_*`, so the glob matches them all.

## Testing

`/doctor` should no longer report this rule as skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)