### PR TITLE
feat: implement Tidal.API + Tidal.API.ExternalClient (+ RequestThrottle) (#140)

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -37,6 +37,10 @@ config :setlistify,
   apple_music_req_options: [
     plug: {Req.Test, MyAppleMusicStub},
     retry: false
+  ],
+  tidal_req_options: [
+    plug: {Req.Test, MyTidalStub},
+    retry: false
   ]
 
 # Disable Apple Music token manager in tests (uses placeholder PEM from .env.example)

--- a/lib/setlistify/music_service/api.ex
+++ b/lib/setlistify/music_service/api.ex
@@ -13,14 +13,18 @@ defmodule Setlistify.MusicService.API do
 
   @type user_session :: Spotify.UserSession.t() | AppleMusic.UserSession.t()
 
+  # Errors are either a bare atom or a tagged 2-tuple; Tidal uses the tuple
+  # form to surface rate limiting as `{:error, {:rate_limited, retry_after}}`.
+  @type error :: {:error, atom() | {atom(), term()}}
+
   @callback search_for_track(user_session(), String.t(), String.t(), String.t() | nil) ::
-              nil | %{track_id: String.t()} | {:error, atom()}
+              nil | %{track_id: String.t()} | error()
 
   @callback create_playlist(user_session(), String.t(), String.t()) ::
-              {:ok, %{id: String.t(), external_url: String.t()}} | {:error, atom()}
+              {:ok, %{id: String.t(), external_url: String.t()}} | error()
 
   @callback add_tracks_to_playlist(user_session(), String.t(), [String.t()]) ::
-              {:ok, atom()} | {:error, atom()}
+              {:ok, atom()} | error()
 
   defp impl(%Spotify.UserSession{}) do
     OpenTelemetry.Tracer.set_attribute("peer.service", "spotify")

--- a/lib/setlistify/tidal/api.ex
+++ b/lib/setlistify/tidal/api.ex
@@ -1,15 +1,59 @@
 defmodule Setlistify.Tidal.API do
   @moduledoc """
-  Dispatch surface for Tidal token operations.
+  Interface module for Tidal API operations.
 
-  Only the token-refresh seam needed by `Setlistify.Tidal.SessionManager` is
-  defined here. The full music-service surface — `search_for_track/4`,
-  `create_playlist/3`, `add_tracks_to_playlist/3`, OAuth `exchange_code/3` and
-  the `Setlistify.MusicService.API` behaviour — lands with the
-  `Setlistify.Tidal.API.ExternalClient` HTTP implementation in #140.
+  Implements the provider-agnostic `Setlistify.MusicService.API` behaviour and
+  adds the Tidal-specific OAuth surface (`exchange_code/3` with a PKCE
+  verifier, `refresh_token/1`, `refresh_to_user_session/1`).
+
+  There is deliberately no `get_embed/1`: Setlistify-created Tidal playlists
+  default to `UNLISTED`, which Tidal's embed player refuses to render, so the
+  `/playlists` page links out to tidal.com instead (ADR-004 §4).
   """
 
+  @behaviour Setlistify.MusicService.API
+
+  alias Setlistify.Tidal.UserSession
+
   require OpenTelemetry.Tracer
+
+  @callback search_for_track(UserSession.t(), String.t(), String.t(), String.t() | nil) ::
+              nil | %{track_id: String.t()} | {:error, atom() | {atom(), term()}}
+  def search_for_track(user_session, artist, track, cover_artist \\ nil) do
+    Setlistify.Cache.fetch(
+      :tidal_track_cache,
+      {artist, track, cover_artist},
+      fn _ -> impl().search_for_track(user_session, artist, track, cover_artist) end
+    )
+  end
+
+  @callback create_playlist(UserSession.t(), String.t(), String.t()) ::
+              {:ok, %{id: String.t(), external_url: String.t()}}
+              | {:error, atom() | {atom(), term()}}
+  def create_playlist(user_session, name, description), do: impl().create_playlist(user_session, name, description)
+
+  @callback add_tracks_to_playlist(UserSession.t(), String.t(), [String.t()]) ::
+              {:ok, atom()} | {:error, atom() | {atom(), term()}}
+  def add_tracks_to_playlist(user_session, playlist_id, tracks),
+    do: impl().add_tracks_to_playlist(user_session, playlist_id, tracks)
+
+  @doc """
+  Exchanges an authorization code (plus the PKCE `code_verifier` generated at
+  sign-in) for tokens and builds a `Setlistify.Tidal.UserSession`.
+  """
+  @callback exchange_code(String.t(), String.t(), String.t()) ::
+              {:ok, UserSession.t()} | {:error, atom() | {atom(), term()}}
+  def exchange_code(code, redirect_uri, code_verifier) do
+    OpenTelemetry.Tracer.with_span "Setlistify.Tidal.API.exchange_code" do
+      OpenTelemetry.Tracer.set_attributes([
+        {"peer.service", "tidal"},
+        {"oauth.grant_type", "authorization_code"},
+        {"oauth.redirect_uri", redirect_uri}
+      ])
+
+      impl().exchange_code(code, redirect_uri, code_verifier)
+    end
+  end
 
   @doc """
   Exchanges a Tidal refresh token for a fresh access token.
@@ -29,6 +73,24 @@ defmodule Setlistify.Tidal.API do
       ])
 
       impl().refresh_token(refresh_token)
+    end
+  end
+
+  @doc """
+  Rebuilds a full `Setlistify.Tidal.UserSession` from a stored refresh token,
+  used when restoring a session from the cookie after the session process has
+  gone away.
+  """
+  @callback refresh_to_user_session(String.t()) ::
+              {:ok, UserSession.t()} | {:error, atom() | {atom(), term()}}
+  def refresh_to_user_session(refresh_token) do
+    OpenTelemetry.Tracer.with_span "Setlistify.Tidal.API.refresh_to_user_session" do
+      OpenTelemetry.Tracer.set_attributes([
+        {"peer.service", "tidal"},
+        {"oauth.grant_type", "refresh_token"}
+      ])
+
+      impl().refresh_to_user_session(refresh_token)
     end
   end
 

--- a/lib/setlistify/tidal/api/external_client.ex
+++ b/lib/setlistify/tidal/api/external_client.ex
@@ -1,0 +1,552 @@
+defmodule Setlistify.Tidal.API.ExternalClient do
+  @moduledoc false
+  @behaviour Setlistify.Tidal.API
+
+  alias Setlistify.Tidal.RequestThrottle
+  alias Setlistify.Tidal.SessionManager
+  alias Setlistify.Tidal.UserSession
+
+  require Logger
+  require OpenTelemetry.Tracer
+
+  @catalog_base_url "https://openapi.tidal.com/v2/"
+  @token_base_url "https://auth.tidal.com/v1/oauth2/token"
+  @playlist_url_base "https://tidal.com/playlist/"
+  @json_api_content_type "application/vnd.api+json"
+  @tracks_per_request 20
+
+  defp client(%UserSession{access_token: token}) do
+    default_opts = [
+      base_url: @catalog_base_url,
+      auth: {:bearer, token},
+      headers: [
+        {"accept", @json_api_content_type},
+        {"content-type", @json_api_content_type}
+      ]
+    ]
+
+    config_opts = Application.get_env(:setlistify, :tidal_req_options, [])
+
+    Req.new()
+    |> OpentelemetryReq.attach(propagate_trace_headers: true)
+    |> Req.merge(Keyword.merge(default_opts, config_opts))
+  end
+
+  defp token_client do
+    default_opts = [base_url: @token_base_url]
+    config_opts = Application.get_env(:setlistify, :tidal_req_options, [])
+
+    Req.new()
+    |> OpentelemetryReq.attach()
+    |> Req.merge(Keyword.merge(default_opts, config_opts))
+  end
+
+  # Every Tidal HTTP call goes through the RequestThrottle semaphore: Tidal's
+  # measured burst capacity is only ~8 requests (see ADR-004 §3), so calls
+  # above the cap queue instead of firing-and-429ing.
+  defp throttled_request(request_fn, req) do
+    RequestThrottle.with_slot(fn -> request_fn.(req) end)
+  end
+
+  defp with_token_refresh(user_session, request_fn, context) do
+    req = client(user_session)
+
+    case throttled_request(request_fn, req) do
+      {:ok, %{status: 401}} ->
+        refresh_and_retry(user_session, request_fn, context)
+
+      other ->
+        handle_rate_limit(other)
+    end
+  end
+
+  defp refresh_and_retry(user_session, request_fn, context) do
+    Logger.debug("Token expired during #{context}, attempting to refresh for user_id: #{user_session.user_id}")
+
+    OpenTelemetry.Tracer.with_span "Setlistify.Tidal.API.ExternalClient.with_token_refresh" do
+      case SessionManager.refresh_session(user_session.user_id) do
+        {:ok, new_session} ->
+          Logger.debug("Successfully refreshed token during #{context}, retrying request")
+          new_req = client(new_session)
+          handle_rate_limit(throttled_request(request_fn, new_req))
+
+        {:error, reason} ->
+          Logger.error(
+            "Failed to refresh token during #{context} for user_id #{user_session.user_id}: #{inspect(reason)}"
+          )
+
+          OpenTelemetry.Tracer.set_status(:error, "Token refresh failed: #{inspect(reason)}")
+
+          {:error, :token_refresh_failed}
+      end
+    end
+  end
+
+  # 429s that occur despite the throttle (e.g. multiple users sharing the app
+  # credential) surface as `{:error, {:rate_limited, retry_after}}` — recorded
+  # with semconv HTTP attributes only, never a `tidal.*` namespace.
+  defp handle_rate_limit({:ok, %{status: 429} = response}) do
+    retry_after = retry_after_seconds(response)
+
+    OpenTelemetry.Tracer.set_attributes([{"http.status_code", 429}])
+
+    OpenTelemetry.Tracer.add_event("http.rate_limited", [
+      {"http.response.header.retry_after", retry_after || ""}
+    ])
+
+    Logger.warning("Tidal rate limited request", %{retry_after: retry_after})
+
+    {:error, {:rate_limited, retry_after}}
+  end
+
+  defp handle_rate_limit(other), do: other
+
+  defp retry_after_seconds(response) do
+    response.headers
+    |> Enum.find_value(fn {header, value} ->
+      if String.downcase(header) == "retry-after", do: value
+    end)
+    |> case do
+      [value | _] when is_binary(value) -> parse_retry_after(value)
+      value when is_binary(value) -> parse_retry_after(value)
+      _ -> nil
+    end
+  end
+
+  defp parse_retry_after(value) do
+    case Integer.parse(value) do
+      {seconds, _} -> seconds
+      :error -> nil
+    end
+  end
+
+  def search_for_track(user_session, artist, track, cover_artist \\ nil) do
+    OpenTelemetry.Tracer.with_span "Setlistify.Tidal.API.ExternalClient.search_for_track" do
+      case do_search_for_track(user_session, artist, track) do
+        {:ok, %{track_id: _} = result} ->
+          result
+
+        {:ok, :no_match} when is_binary(cover_artist) ->
+          OpenTelemetry.Tracer.set_attributes([{"search.fallback", "cover_artist"}])
+
+          case do_search_for_track(user_session, cover_artist, track) do
+            {:ok, %{track_id: _} = result} -> result
+            {:ok, :no_match} -> nil
+            {:error, _} = error -> error
+          end
+
+        {:ok, :no_match} ->
+          nil
+
+        {:error, _} = error ->
+          error
+      end
+    end
+  rescue
+    error ->
+      Logger.error("Exception during Tidal search: #{inspect(error)}")
+      OpenTelemetry.Tracer.record_exception(error)
+      OpenTelemetry.Tracer.set_status(:error, "Exception: #{Exception.message(error)}")
+      nil
+  end
+
+  defp do_search_for_track(user_session, artist, track) do
+    # Tidal's search endpoint takes the query as a path segment, not a query
+    # param, so it must be URL-encoded strictly (spaces as %20, not +).
+    query = URI.encode(artist <> " " <> track, &URI.char_unreserved?/1)
+
+    request_fn = fn req ->
+      Req.get(req,
+        url: "/searchResults/#{query}",
+        params: %{countryCode: user_session.country_code, include: "tracks,tracks.artists"}
+      )
+    end
+
+    case with_token_refresh(user_session, request_fn, "track search") do
+      {:ok, %{status: 200} = resp} ->
+        resp.body
+        |> first_track_entry()
+        |> evaluate_search_result(resp.body, artist, track)
+
+      {:error, _} = error ->
+        error
+
+      {:ok, %{status: 401} = response} ->
+        Logger.error("Unauthorized search request with user_id #{user_session.user_id}: #{inspect(response)}")
+
+        {:error, :unauthorized}
+
+      {:ok, response} ->
+        Logger.error("Unexpected response from Tidal search: #{inspect(response)}")
+        {:error, :unexpected_response}
+    end
+  end
+
+  # The search result's tracks arrive as ordered {type, id} references under
+  # data.relationships.tracks.data, with the full track resources in the
+  # flat top-level `included` array.
+  defp first_track_entry(body) do
+    case get_in(body, ["data", "relationships", "tracks", "data"]) do
+      [%{"type" => type, "id" => id} | _] -> extract_included(body, type, id)
+      _ -> nil
+    end
+  end
+
+  defp evaluate_search_result(nil, _body, artist, track) do
+    Logger.warning("No search results", %{artist: artist, track: track})
+
+    OpenTelemetry.Tracer.set_attributes([{"search.outcome", "no_results"}])
+    {:ok, :no_match}
+  end
+
+  defp evaluate_search_result(track_entry, body, artist, track) do
+    result_artists =
+      track_entry
+      |> get_in(["relationships", "artists", "data"])
+      |> List.wrap()
+      |> Enum.map(&resolve_artist_name(body, &1))
+
+    if Enum.any?(result_artists, &artist_match?(artist, &1)) do
+      Logger.info("Found match", %{artist: artist, track: track})
+
+      OpenTelemetry.Tracer.set_attributes([
+        {"track.id", track_entry["id"]},
+        {"search.outcome", "match"}
+      ])
+
+      {:ok, %{track_id: track_entry["id"]}}
+    else
+      Logger.warning("Rejected search result: artist mismatch", %{
+        queried_artist: artist,
+        returned_artists: result_artists,
+        track: track
+      })
+
+      OpenTelemetry.Tracer.set_attributes([{"search.outcome", "rejected_artist_mismatch"}])
+
+      OpenTelemetry.Tracer.add_event("search.result_rejected", [
+        {"reason", "artist_mismatch"},
+        {"queried_artist", artist},
+        {"returned_artists", Enum.map_join(result_artists, ", ", &(&1 || ""))},
+        {"track", track}
+      ])
+
+      {:ok, :no_match}
+    end
+  end
+
+  # Resolves a {type, id} relationships reference against the top-level
+  # included list. The included array is flat across all search-result tracks'
+  # relationships, so always resolve by {type, id} lookup, never by index.
+  defp extract_included(%{"included" => included}, type, id) when is_list(included) do
+    Enum.find(included, fn entry -> entry["type"] == type && entry["id"] == id end)
+  end
+
+  defp extract_included(_body, _type, _id), do: nil
+
+  # A reference that resolves to nothing in `included` yields nil, which
+  # artist_match?/2 treats as a mismatch — falling into the cover-fallback path.
+  defp resolve_artist_name(body, %{"type" => type, "id" => id}) do
+    case extract_included(body, type, id) do
+      %{"attributes" => %{"name" => name}} -> name
+      _ -> nil
+    end
+  end
+
+  defp resolve_artist_name(_body, _ref), do: nil
+
+  defp artist_match?(_queried, nil), do: false
+
+  defp artist_match?(queried, returned) do
+    String.equivalent?(normalize_artist(queried), normalize_artist(returned))
+  end
+
+  defp normalize_artist(name), do: name |> String.downcase() |> String.trim()
+
+  def create_playlist(user_session, name, description) do
+    OpenTelemetry.Tracer.with_span "Setlistify.Tidal.API.ExternalClient.create_playlist" do
+      Logger.info("Creating playlist", %{
+        name: name,
+        user_id: user_session.user_id
+      })
+
+      request_fn = fn req ->
+        Req.post(req,
+          url: "/playlists",
+          params: %{countryCode: user_session.country_code},
+          headers: [{"idempotency-key", idempotency_key([user_session.user_id, name, description])}],
+          json: %{
+            data: %{
+              type: "playlists",
+              attributes: %{
+                name: name,
+                description: description,
+                # UNLISTED (owner-only) rather than PUBLIC; Tidal rejects
+                # "PRIVATE" outright. See ADR-004 §4.
+                accessType: "UNLISTED"
+              }
+            }
+          }
+        )
+      end
+
+      case with_token_refresh(user_session, request_fn, "playlist creation") do
+        {:ok, %{status: 201} = resp} ->
+          playlist_id = resp.body |> Map.fetch!("data") |> Map.fetch!("id")
+          external_url = @playlist_url_base <> playlist_id
+
+          OpenTelemetry.Tracer.set_attributes([
+            {"playlist.id", playlist_id},
+            {"playlist.url", external_url}
+          ])
+
+          Logger.info("Playlist created successfully", %{
+            playlist_id: playlist_id,
+            name: name
+          })
+
+          {:ok, %{id: playlist_id, external_url: external_url}}
+
+        {:ok, response} ->
+          Logger.error("Unexpected response creating playlist: #{inspect(response)}")
+
+          OpenTelemetry.Tracer.set_status(
+            :error,
+            "Unexpected response: status #{response.status}"
+          )
+
+          {:error, :playlist_creation_failed}
+
+        {:error, reason} = error ->
+          OpenTelemetry.Tracer.set_status(:error, inspect(reason))
+          error
+      end
+    end
+  end
+
+  def add_tracks_to_playlist(_, _, []), do: {:ok, :no_tracks}
+
+  def add_tracks_to_playlist(user_session, playlist_id, tracks) do
+    OpenTelemetry.Tracer.with_span "Setlistify.Tidal.API.ExternalClient.add_tracks_to_playlist" do
+      Logger.info("Adding tracks to playlist", %{
+        playlist_id: playlist_id,
+        track_count: length(tracks),
+        user_id: user_session.user_id
+      })
+
+      result =
+        tracks
+        |> Enum.chunk_every(@tracks_per_request)
+        |> Enum.reduce_while(:ok, fn chunk, :ok ->
+          case add_track_chunk(user_session, playlist_id, chunk) do
+            :ok -> {:cont, :ok}
+            {:error, _} = error -> {:halt, error}
+          end
+        end)
+
+      case result do
+        :ok ->
+          Logger.info("Tracks added successfully", %{
+            playlist_id: playlist_id,
+            track_count: length(tracks)
+          })
+
+          {:ok, :tracks_added}
+
+        {:error, reason} = error ->
+          OpenTelemetry.Tracer.set_status(:error, inspect(reason))
+          error
+      end
+    end
+  end
+
+  defp add_track_chunk(user_session, playlist_id, chunk) do
+    request_fn = fn req ->
+      Req.post(req,
+        url: "/playlists/#{playlist_id}/relationships/items",
+        params: %{countryCode: user_session.country_code},
+        headers: [{"idempotency-key", idempotency_key([playlist_id | chunk])}],
+        # No meta.positionBefore: it's a no-op for new appends, and natural
+        # append-to-end is exactly what we want for setlist-derived playlists.
+        json: %{data: Enum.map(chunk, &%{id: &1, type: "tracks"})}
+      )
+    end
+
+    case with_token_refresh(user_session, request_fn, "adding tracks to playlist") do
+      {:ok, %{status: status}} when status in [200, 201, 204] ->
+        :ok
+
+      {:ok, response} ->
+        Logger.error("Failed to add tracks to playlist: #{inspect(response)}")
+        {:error, :tracks_addition_failed}
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  # A deterministic Idempotency-Key so retries of the same logical operation
+  # (same user + playlist name + description, or same playlist + track chunk)
+  # dedupe server-side instead of creating duplicates. Colliding across two
+  # genuinely identical requests is the behavior we want — duplicate playlists
+  # from retried creates are exactly the bug idempotency keys exist to prevent.
+  defp idempotency_key(parts) do
+    :sha256
+    |> :crypto.hash(Enum.intersperse(parts, "\n"))
+    |> Base.encode16(case: :lower)
+  end
+
+  def refresh_token(refresh_token) do
+    OpenTelemetry.Tracer.with_span "Setlistify.Tidal.API.ExternalClient.refresh_token" do
+      OpenTelemetry.Tracer.set_attributes([
+        {"oauth.provider", "tidal"},
+        {"oauth.grant_type", "refresh_token"}
+      ])
+
+      client_id = Application.fetch_env!(:setlistify, :tidal_client_id)
+      client_secret = Application.fetch_env!(:setlistify, :tidal_client_secret)
+
+      result =
+        throttled_request(
+          fn req ->
+            Req.post(req,
+              form: %{
+                grant_type: "refresh_token",
+                refresh_token: refresh_token,
+                client_id: client_id,
+                client_secret: client_secret
+              }
+            )
+          end,
+          token_client()
+        )
+
+      case result do
+        {:ok, %{status: 200, body: body}} ->
+          Logger.info("Successfully refreshed Tidal token")
+
+          # Tidal does NOT rotate refresh tokens — the response carries no
+          # refresh_token field, so callers keep the one they already hold.
+          {:ok,
+           %{
+             access_token: Map.fetch!(body, "access_token"),
+             expires_in: Map.fetch!(body, "expires_in")
+           }}
+
+        {:ok, %{status: status}} when status in [400, 401] ->
+          Logger.error("Tidal token refresh failed with status #{status}")
+          OpenTelemetry.Tracer.set_status(:error, "Invalid token: status #{status}")
+          {:error, :invalid_token}
+
+        error ->
+          Logger.error("Tidal token refresh error: #{inspect(error)}")
+          OpenTelemetry.Tracer.set_status(:error, "Refresh failed: #{inspect(error)}")
+          {:error, :refresh_failed}
+      end
+    end
+  end
+
+  def refresh_to_user_session(refresh_token) do
+    case refresh_token(refresh_token) do
+      {:ok, tokens} ->
+        # Tidal doesn't rotate refresh tokens, so the new session keeps the
+        # refresh token we already hold.
+        build_user_session_from_tokens(tokens.access_token, refresh_token, tokens.expires_in)
+
+      {:error, reason} = error ->
+        Logger.error("Failed to refresh Tidal token: #{inspect(reason)}")
+        error
+    end
+  end
+
+  def exchange_code(code, redirect_uri, code_verifier) do
+    OpenTelemetry.Tracer.with_span "Setlistify.Tidal.API.ExternalClient.exchange_code" do
+      OpenTelemetry.Tracer.set_attributes([
+        {"oauth.provider", "tidal"},
+        {"oauth.redirect_uri", redirect_uri}
+      ])
+
+      client_id = Application.fetch_env!(:setlistify, :tidal_client_id)
+      client_secret = Application.fetch_env!(:setlistify, :tidal_client_secret)
+
+      result =
+        throttled_request(
+          fn req ->
+            Req.post(req,
+              form: %{
+                grant_type: "authorization_code",
+                code: code,
+                redirect_uri: redirect_uri,
+                client_id: client_id,
+                client_secret: client_secret,
+                # Tidal (OAuth 2.1) mandates PKCE for all clients, even
+                # confidential ones that also send a client_secret.
+                code_verifier: code_verifier
+              }
+            )
+          end,
+          token_client()
+        )
+
+      case result do
+        {:ok, %{status: 200, body: body}} ->
+          Logger.info("Successfully exchanged code for Tidal tokens")
+
+          build_user_session_from_tokens(
+            Map.fetch!(body, "access_token"),
+            Map.fetch!(body, "refresh_token"),
+            Map.fetch!(body, "expires_in")
+          )
+
+        {:ok, %{status: status, body: body}} when status in [400, 401] ->
+          Logger.error("Failed to exchange code: Invalid code. Status: #{status}, Error: #{inspect(body)}")
+
+          OpenTelemetry.Tracer.set_status(:error, "Invalid code: status #{status}")
+
+          {:error, :invalid_code}
+
+        {:ok, %{status: status, body: body}} ->
+          Logger.error("Failed to exchange code. Status: #{status}, Error: #{inspect(body)}")
+          OpenTelemetry.Tracer.set_status(:error, "Unexpected status: #{status}")
+          {:error, {:unexpected_status, status, body}}
+
+        {:error, error} ->
+          Logger.error("Error exchanging code: #{inspect(error)}")
+          OpenTelemetry.Tracer.set_status(:error, "Exchange failed: #{inspect(error)}")
+          {:error, :exchange_failed}
+      end
+    end
+  end
+
+  # DELIBERATE NON-STANDARD: we treat Tidal's access-token JWT internals as a
+  # stable interface. The OAuth spec says treat access tokens as opaque, but
+  # deriving user_id/country_code from the `uid`/`cc` claims saves a network
+  # round-trip at sign-in (verified against /v2/users/me in the Phase 0 spike).
+  # If Tidal ever rotates these claim names or moves to opaque tokens, switch
+  # back to a GET /v2/users/me call — its response shape is documented in
+  # ADR-004 §1 and the issue #137 findings. Map.fetch! is intentional: a
+  # missing claim must blow up sign-in loudly, not silently corrupt a session.
+  defp build_user_session_from_tokens(access_token, refresh_token, expires_in) do
+    claims = decode_jwt_payload!(access_token)
+
+    {:ok,
+     %UserSession{
+       access_token: access_token,
+       refresh_token: refresh_token,
+       expires_at: System.system_time(:second) + expires_in,
+       user_id: claims |> Map.fetch!("uid") |> to_string(),
+       country_code: Map.fetch!(claims, "cc")
+     }}
+  end
+
+  # Decodes the payload segment of a JWT without verifying the signature — we
+  # aren't validating someone else's token, this one came straight from Tidal
+  # in response to our own token request.
+  defp decode_jwt_payload!(access_token) do
+    [_header, payload, _signature] = String.split(access_token, ".")
+
+    payload
+    |> Base.url_decode64!(padding: false)
+    |> JSON.decode!()
+  end
+end

--- a/lib/setlistify/tidal/request_throttle.ex
+++ b/lib/setlistify/tidal/request_throttle.ex
@@ -1,0 +1,112 @@
+defmodule Setlistify.Tidal.RequestThrottle do
+  @moduledoc """
+  Caps the number of in-flight Tidal HTTP requests.
+
+  Tidal's real-world rate limit (measured in the Phase 0 spike, issue #137) is
+  a ~8-request burst followed by ~2-3 sustained requests/sec with a flat
+  `Retry-After: 4` on every 429. The LiveView search fan-out fires a request
+  per song in a setlist, so a 20-song setlist would blow through the burst
+  capacity without coordination.
+
+  This is a small semaphore: `with_slot/2` blocks until one of
+  `@max_concurrent` slots is free, runs the function in the caller's process,
+  and releases the slot when it returns (or when the caller dies). Calls above
+  the cap queue instead of firing-and-429ing. It is scoped to the Tidal
+  subtree only — Spotify and Apple Music are not throttled here.
+
+  Emits a `[:setlistify, :music_service, :request_throttle, :acquired]`
+  telemetry event with a `queue_time` measurement (milliseconds spent waiting
+  for a slot) and `%{music_service: "tidal"}` metadata, so Phase 2 (#146) can
+  tell whether the cap is squeezing concurrency too tight.
+  """
+
+  use GenServer
+
+  # Sized to stay inside the spike's measured burst capacity (8) with headroom.
+  @max_concurrent 4
+
+  @telemetry_event [:setlistify, :music_service, :request_throttle, :acquired]
+
+  def start_link(opts \\ []) do
+    {max_concurrent, opts} = Keyword.pop(opts, :max_concurrent, @max_concurrent)
+    opts = Keyword.put_new(opts, :name, __MODULE__)
+
+    GenServer.start_link(__MODULE__, max_concurrent, opts)
+  end
+
+  @doc """
+  Runs `fun` once an in-flight slot is free, releasing the slot afterwards.
+
+  Blocks (without timeout) until a slot is available. The function runs in the
+  caller's process, so concurrency is only limited — never serialized through
+  this GenServer.
+  """
+  def with_slot(server \\ __MODULE__, fun) when is_function(fun, 0) do
+    queued_at = System.monotonic_time()
+    :ok = GenServer.call(server, :acquire, :infinity)
+
+    queue_time =
+      System.convert_time_unit(System.monotonic_time() - queued_at, :native, :millisecond)
+
+    :telemetry.execute(@telemetry_event, %{queue_time: queue_time}, %{music_service: "tidal"})
+
+    try do
+      fun.()
+    after
+      GenServer.cast(server, {:release, self()})
+    end
+  end
+
+  @impl true
+  def init(max_concurrent) do
+    {:ok, %{max_concurrent: max_concurrent, holders: %{}, queue: :queue.new()}}
+  end
+
+  @impl true
+  def handle_call(:acquire, {pid, _tag} = from, state) do
+    if map_size(state.holders) < state.max_concurrent do
+      {:reply, :ok, grant(state, pid)}
+    else
+      {:noreply, %{state | queue: :queue.in({from, pid}, state.queue)}}
+    end
+  end
+
+  @impl true
+  def handle_cast({:release, pid}, state) do
+    {:noreply, release(state, pid)}
+  end
+
+  # A slot holder (or a queued waiter that was later granted a slot) died
+  # without releasing — free its slot so the queue keeps draining.
+  @impl true
+  def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
+    {:noreply, release(state, pid)}
+  end
+
+  defp grant(state, pid) do
+    ref = Process.monitor(pid)
+    %{state | holders: Map.put(state.holders, pid, ref)}
+  end
+
+  defp release(state, pid) do
+    case Map.pop(state.holders, pid) do
+      {nil, _holders} ->
+        state
+
+      {ref, holders} ->
+        Process.demonitor(ref, [:flush])
+        promote_next(%{state | holders: holders})
+    end
+  end
+
+  defp promote_next(state) do
+    case :queue.out(state.queue) do
+      {{:value, {from, pid}}, queue} ->
+        GenServer.reply(from, :ok)
+        grant(%{state | queue: queue}, pid)
+
+      {:empty, _queue} ->
+        state
+    end
+  end
+end

--- a/test/setlistify/tidal/api/external_client_test.exs
+++ b/test/setlistify/tidal/api/external_client_test.exs
@@ -1,0 +1,605 @@
+defmodule Setlistify.Tidal.Api.ExternalClientTest do
+  use Setlistify.DataCase, async: true
+
+  import Hammox
+
+  alias Setlistify.Tidal.API.ExternalClient
+  alias Setlistify.Tidal.API.MockClient
+  alias Setlistify.Tidal.RequestThrottle
+  alias Setlistify.Tidal.SessionSupervisor
+  alias Setlistify.Tidal.UserSession
+
+  @user_id "12345"
+  @country_code "US"
+  @json_api_content_type "application/vnd.api+json"
+
+  setup do
+    Req.Test.verify_on_exit!()
+    start_supervised!(RequestThrottle)
+
+    user_session = %UserSession{
+      access_token: "token",
+      refresh_token: "refresh_token",
+      expires_at: System.system_time(:second) + 14_400,
+      user_id: @user_id,
+      country_code: @country_code
+    }
+
+    {:ok, user_session: user_session}
+  end
+
+  # Builds a JSON:API search response body. Track references live under
+  # data.relationships.tracks.data; the track and artist resources arrive in a
+  # single flat top-level `included` list.
+  defp search_response(tracks) do
+    track_resources =
+      Enum.map(tracks, fn track ->
+        %{
+          "id" => track.id,
+          "type" => "tracks",
+          "attributes" => %{"title" => track.title},
+          "relationships" => %{
+            "artists" => %{
+              "data" => Enum.map(track.artists, &%{"id" => &1.id, "type" => "artists"})
+            }
+          }
+        }
+      end)
+
+    artist_resources =
+      tracks
+      |> Enum.flat_map(& &1.artists)
+      |> Enum.uniq_by(& &1.id)
+      |> Enum.map(&%{"id" => &1.id, "type" => "artists", "attributes" => %{"name" => &1.name}})
+
+    %{
+      "data" => %{
+        "id" => "search-query-id",
+        "type" => "searchResults",
+        "relationships" => %{
+          "tracks" => %{"data" => Enum.map(tracks, &%{"id" => &1.id, "type" => "tracks"})}
+        }
+      },
+      "included" => track_resources ++ artist_resources
+    }
+  end
+
+  defp json_api_resp(conn, status, body) do
+    conn
+    |> Plug.Conn.put_resp_header("content-type", "#{@json_api_content_type}; charset=utf-8")
+    |> Plug.Conn.send_resp(status, JSON.encode!(body))
+  end
+
+  # A syntactically valid JWT carrying the given claims in its payload — the
+  # signature is not verified by the client, so a placeholder segment is fine.
+  defp jwt(claims) do
+    header = Base.url_encode64(JSON.encode!(%{"alg" => "ES256", "typ" => "JWT"}), padding: false)
+    payload = Base.url_encode64(JSON.encode!(claims), padding: false)
+
+    "#{header}.#{payload}.placeholder-signature"
+  end
+
+  describe "search_for_track/4" do
+    test "returns the first matching track resolved through included", %{user_session: user_session} do
+      Req.Test.stub(MyTidalStub, fn %{method: "GET"} = conn ->
+        assert conn.request_path =~ "/v2/searchResults/Modest%20Mouse%20Lace%20Your%20Shoes"
+
+        conn = Plug.Conn.fetch_query_params(conn)
+        assert conn.query_params["countryCode"] == @country_code
+        assert conn.query_params["include"] == "tracks,tracks.artists"
+
+        json_api_resp(
+          conn,
+          200,
+          search_response([
+            %{id: "251380837", title: "Lace Your Shoes", artists: [%{id: "9x1", name: "Modest Mouse"}]}
+          ])
+        )
+      end)
+
+      assert %{track_id: "251380837"} =
+               ExternalClient.search_for_track(user_session, "Modest Mouse", "Lace Your Shoes")
+    end
+
+    test "returns nil when the search has no results", %{user_session: user_session} do
+      Req.Test.stub(MyTidalStub, fn conn ->
+        json_api_resp(conn, 200, search_response([]))
+      end)
+
+      ExUnit.CaptureLog.capture_log(fn ->
+        assert ExternalClient.search_for_track(user_session, "some artist", "some track") == nil
+      end)
+    end
+
+    test "returns nil when the response carries no relationships at all", %{user_session: user_session} do
+      Req.Test.stub(MyTidalStub, fn conn ->
+        json_api_resp(conn, 200, %{"data" => %{"id" => "q", "type" => "searchResults"}})
+      end)
+
+      ExUnit.CaptureLog.capture_log(fn ->
+        assert ExternalClient.search_for_track(user_session, "some artist", "some track") == nil
+      end)
+    end
+
+    test "rejects results whose artist does not match the queried artist", %{user_session: user_session} do
+      Req.Test.stub(MyTidalStub, fn conn ->
+        json_api_resp(
+          conn,
+          200,
+          search_response([
+            %{id: "77", title: "Still Don't Know My Name", artists: [%{id: "a1", name: "Labrinth"}]}
+          ])
+        )
+      end)
+
+      ExUnit.CaptureLog.capture_log(fn ->
+        assert ExternalClient.search_for_track(user_session, "Tim Kasher", "From the Hips") == nil
+      end)
+    end
+
+    test "treats an artist reference missing from included as a mismatch", %{user_session: user_session} do
+      Req.Test.stub(MyTidalStub, fn conn ->
+        body = search_response([%{id: "88", title: "From the Hips", artists: []}])
+
+        # The track references an artist that never appears in `included`.
+        body =
+          put_in(
+            body,
+            ["included", Access.at(0), "relationships", "artists", "data"],
+            [%{"id" => "missing-artist", "type" => "artists"}]
+          )
+
+        json_api_resp(conn, 200, body)
+      end)
+
+      ExUnit.CaptureLog.capture_log(fn ->
+        assert ExternalClient.search_for_track(user_session, "Tim Kasher", "From the Hips") == nil
+      end)
+    end
+
+    test "falls back to cover artist when performing artist returns no usable match",
+         %{user_session: user_session} do
+      Req.Test.expect(MyTidalStub, fn conn ->
+        assert conn.request_path =~ "Tim%20Kasher"
+        json_api_resp(conn, 200, search_response([]))
+      end)
+
+      Req.Test.expect(MyTidalStub, fn conn ->
+        assert conn.request_path =~ "Cursive"
+
+        json_api_resp(
+          conn,
+          200,
+          search_response([
+            %{id: "cursive1", title: "Driftwood: A Fairy Tale", artists: [%{id: "c1", name: "Cursive"}]}
+          ])
+        )
+      end)
+
+      ExUnit.CaptureLog.capture_log(fn ->
+        assert %{track_id: "cursive1"} =
+                 ExternalClient.search_for_track(
+                   user_session,
+                   "Tim Kasher",
+                   "Driftwood: A Fairy Tale",
+                   "Cursive"
+                 )
+      end)
+    end
+
+    test "propagates primary search error without attempting cover artist fallback",
+         %{user_session: user_session} do
+      Req.Test.expect(MyTidalStub, fn conn ->
+        assert conn.request_path =~ "Tim%20Kasher"
+        refute conn.request_path =~ "Cursive"
+        Plug.Conn.send_resp(conn, 500, "Internal Server Error")
+      end)
+
+      ExUnit.CaptureLog.capture_log(fn ->
+        assert {:error, :unexpected_response} =
+                 ExternalClient.search_for_track(
+                   user_session,
+                   "Tim Kasher",
+                   "Driftwood: A Fairy Tale",
+                   "Cursive"
+                 )
+      end)
+    end
+
+    test "surfaces a 429 as {:error, {:rate_limited, retry_after}}", %{user_session: user_session} do
+      Req.Test.expect(MyTidalStub, fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("retry-after", "4")
+        |> Plug.Conn.send_resp(429, "")
+      end)
+
+      ExUnit.CaptureLog.capture_log(fn ->
+        assert {:error, {:rate_limited, 4}} =
+                 ExternalClient.search_for_track(user_session, "Modest Mouse", "Dramamine", "Cursive")
+      end)
+    end
+
+    test "rate limited response without a retry-after header yields nil retry hint",
+         %{user_session: user_session} do
+      Req.Test.expect(MyTidalStub, fn conn ->
+        Plug.Conn.send_resp(conn, 429, "")
+      end)
+
+      ExUnit.CaptureLog.capture_log(fn ->
+        assert {:error, {:rate_limited, nil}} =
+                 ExternalClient.search_for_track(user_session, "Modest Mouse", "Dramamine")
+      end)
+    end
+  end
+
+  describe "create_playlist/3" do
+    test "creates an UNLISTED playlist with a JSON:API body and idempotency key",
+         %{user_session: user_session} do
+      Req.Test.stub(MyTidalStub, fn %{method: "POST"} = conn ->
+        assert conn.request_path == "/v2/playlists"
+
+        conn = Plug.Conn.fetch_query_params(conn)
+        assert conn.query_params["countryCode"] == @country_code
+
+        assert [@json_api_content_type <> _] = Plug.Conn.get_req_header(conn, "content-type")
+        assert [idempotency_key] = Plug.Conn.get_req_header(conn, "idempotency-key")
+        assert idempotency_key =~ ~r/^[0-9a-f]{64}$/
+
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+
+        assert JSON.decode!(body) == %{
+                 "data" => %{
+                   "type" => "playlists",
+                   "attributes" => %{
+                     "name" => "Test Playlist",
+                     "description" => "Test Description",
+                     "accessType" => "UNLISTED"
+                   }
+                 }
+               }
+
+        json_api_resp(conn, 201, %{
+          "data" => %{"id" => "5a1b2c3d-4e5f-6071-8293-a4b5c6d7e8f9", "type" => "playlists"}
+        })
+      end)
+
+      assert {:ok, playlist} =
+               ExternalClient.create_playlist(user_session, "Test Playlist", "Test Description")
+
+      assert playlist.id == "5a1b2c3d-4e5f-6071-8293-a4b5c6d7e8f9"
+      assert playlist.external_url == "https://tidal.com/playlist/5a1b2c3d-4e5f-6071-8293-a4b5c6d7e8f9"
+    end
+
+    test "sends the same idempotency key for identical create requests", %{user_session: user_session} do
+      test_pid = self()
+
+      Req.Test.expect(MyTidalStub, 2, fn conn ->
+        [key] = Plug.Conn.get_req_header(conn, "idempotency-key")
+        send(test_pid, {:idempotency_key, key})
+
+        json_api_resp(conn, 201, %{"data" => %{"id" => "same-playlist", "type" => "playlists"}})
+      end)
+
+      {:ok, _} = ExternalClient.create_playlist(user_session, "Name", "Description")
+      {:ok, _} = ExternalClient.create_playlist(user_session, "Name", "Description")
+
+      assert_receive {:idempotency_key, first_key}
+      assert_receive {:idempotency_key, second_key}
+      assert first_key == second_key
+    end
+
+    @tag :capture_log
+    test "returns an error on an unexpected status", %{user_session: user_session} do
+      Req.Test.expect(MyTidalStub, fn conn ->
+        json_api_resp(conn, 400, %{
+          "errors" => [%{"code" => "INVALID_REQUEST_BODY", "detail" => "bad"}]
+        })
+      end)
+
+      assert {:error, :playlist_creation_failed} =
+               ExternalClient.create_playlist(user_session, "Test Playlist", "Test Description")
+    end
+
+    @tag :capture_log
+    test "surfaces a 429 as {:error, {:rate_limited, retry_after}}", %{user_session: user_session} do
+      Req.Test.expect(MyTidalStub, fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("retry-after", "4")
+        |> Plug.Conn.send_resp(429, "")
+      end)
+
+      assert {:error, {:rate_limited, 4}} =
+               ExternalClient.create_playlist(user_session, "Test Playlist", "Test Description")
+    end
+  end
+
+  describe "add_tracks_to_playlist/3" do
+    test "adds tracks in chunks of 20 with per-chunk idempotency keys", %{user_session: user_session} do
+      test_pid = self()
+      tracks = Enum.map(1..45, &"track-#{&1}")
+
+      Req.Test.expect(MyTidalStub, 3, fn %{method: "POST"} = conn ->
+        assert conn.request_path == "/v2/playlists/playlist123/relationships/items"
+
+        conn = Plug.Conn.fetch_query_params(conn)
+        assert conn.query_params["countryCode"] == @country_code
+
+        [idempotency_key] = Plug.Conn.get_req_header(conn, "idempotency-key")
+
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        %{"data" => data} = JSON.decode!(body)
+
+        assert Enum.all?(data, &(&1["type"] == "tracks"))
+        refute Map.has_key?(JSON.decode!(body), "meta")
+
+        send(test_pid, {:chunk, Enum.map(data, & &1["id"]), idempotency_key})
+
+        Plug.Conn.send_resp(conn, 201, "")
+      end)
+
+      assert {:ok, :tracks_added} =
+               ExternalClient.add_tracks_to_playlist(user_session, "playlist123", tracks)
+
+      assert_receive {:chunk, first_chunk, first_key}
+      assert_receive {:chunk, second_chunk, second_key}
+      assert_receive {:chunk, third_chunk, third_key}
+
+      assert first_chunk == Enum.map(1..20, &"track-#{&1}")
+      assert second_chunk == Enum.map(21..40, &"track-#{&1}")
+      assert third_chunk == Enum.map(41..45, &"track-#{&1}")
+
+      assert [first_key, second_key, third_key] |> Enum.uniq() |> length() == 3
+    end
+
+    @tag :capture_log
+    test "halts on the first failing chunk", %{user_session: user_session} do
+      tracks = Enum.map(1..25, &"track-#{&1}")
+
+      Req.Test.expect(MyTidalStub, fn conn -> Plug.Conn.send_resp(conn, 201, "") end)
+      Req.Test.expect(MyTidalStub, fn conn -> Plug.Conn.send_resp(conn, 500, "") end)
+
+      assert {:error, :tracks_addition_failed} =
+               ExternalClient.add_tracks_to_playlist(user_session, "playlist123", tracks)
+    end
+
+    @tag :capture_log
+    test "surfaces a mid-chunk 429 as {:error, {:rate_limited, retry_after}}",
+         %{user_session: user_session} do
+      tracks = Enum.map(1..25, &"track-#{&1}")
+
+      Req.Test.expect(MyTidalStub, fn conn -> Plug.Conn.send_resp(conn, 201, "") end)
+
+      Req.Test.expect(MyTidalStub, fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("retry-after", "4")
+        |> Plug.Conn.send_resp(429, "")
+      end)
+
+      assert {:error, {:rate_limited, 4}} =
+               ExternalClient.add_tracks_to_playlist(user_session, "playlist123", tracks)
+    end
+
+    test "handles empty track list gracefully", %{user_session: user_session} do
+      assert {:ok, :no_tracks} =
+               ExternalClient.add_tracks_to_playlist(user_session, "playlist123", [])
+    end
+  end
+
+  describe "refresh_token/1" do
+    test "returns the new access token without a refresh token (Tidal does not rotate)" do
+      Req.Test.expect(MyTidalStub, fn conn ->
+        assert conn.request_path == "/v1/oauth2/token"
+
+        assert "application/x-www-form-urlencoded" in Plug.Conn.get_req_header(conn, "content-type")
+
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        params = URI.decode_query(body)
+
+        assert params["grant_type"] == "refresh_token"
+        assert params["refresh_token"] == "old_refresh_token"
+        assert params["client_id"]
+        assert params["client_secret"]
+
+        # Tidal's refresh response has NO refresh_token field.
+        Req.Test.json(conn, %{
+          "access_token" => "new_access_token",
+          "expires_in" => 14_400,
+          "token_type" => "Bearer",
+          "scope" => "user.read playlists.write",
+          "user_id" => 12_345
+        })
+      end)
+
+      assert {:ok, tokens} = ExternalClient.refresh_token("old_refresh_token")
+      assert tokens == %{access_token: "new_access_token", expires_in: 14_400}
+    end
+
+    @tag :capture_log
+    test "returns error on invalid token" do
+      Req.Test.expect(MyTidalStub, fn conn -> Plug.Conn.send_resp(conn, 401, "Unauthorized") end)
+
+      assert {:error, :invalid_token} = ExternalClient.refresh_token("invalid_token")
+    end
+
+    @tag :capture_log
+    test "returns error on server error" do
+      Req.Test.expect(MyTidalStub, fn conn ->
+        Plug.Conn.send_resp(conn, 500, "Internal Server Error")
+      end)
+
+      assert {:error, :refresh_failed} = ExternalClient.refresh_token("some_token")
+    end
+  end
+
+  describe "refresh_to_user_session/1" do
+    test "builds the session from the JWT claims, preserving the refresh token" do
+      access_token = jwt(%{"uid" => 12_345, "cc" => "US"})
+
+      Req.Test.expect(MyTidalStub, fn conn ->
+        Req.Test.json(conn, %{"access_token" => access_token, "expires_in" => 14_400})
+      end)
+
+      assert {:ok, %UserSession{} = user_session} =
+               ExternalClient.refresh_to_user_session("stored_refresh_token")
+
+      assert user_session.access_token == access_token
+      assert user_session.refresh_token == "stored_refresh_token"
+      assert user_session.user_id == "12345"
+      assert user_session.country_code == "US"
+      assert user_session.expires_at > System.system_time(:second)
+    end
+
+    @tag :capture_log
+    test "returns error when token refresh fails" do
+      Req.Test.expect(MyTidalStub, fn conn ->
+        Plug.Conn.send_resp(conn, 401, "Unauthorized")
+      end)
+
+      assert {:error, :invalid_token} = ExternalClient.refresh_to_user_session("bad_token")
+    end
+  end
+
+  describe "exchange_code/3" do
+    test "exchanges the code with the PKCE verifier and builds the session from JWT claims" do
+      access_token = jwt(%{"uid" => 12_345, "cc" => "NO"})
+
+      Req.Test.expect(MyTidalStub, fn conn ->
+        assert conn.request_path == "/v1/oauth2/token"
+
+        {:ok, body, conn} = Plug.Conn.read_body(conn)
+        params = URI.decode_query(body)
+
+        assert params["grant_type"] == "authorization_code"
+        assert params["code"] == "valid_code"
+        assert params["redirect_uri"] == "http://127.0.0.1:4000/oauth/callbacks/tidal"
+        assert params["code_verifier"] == "pkce_verifier"
+        assert params["client_id"]
+        assert params["client_secret"]
+
+        Req.Test.json(conn, %{
+          "access_token" => access_token,
+          "refresh_token" => "new_refresh_token",
+          "expires_in" => 14_400,
+          "token_type" => "Bearer",
+          "scope" => "user.read playlists.write",
+          "user_id" => 12_345
+        })
+      end)
+
+      assert {:ok, %UserSession{} = user_session} =
+               ExternalClient.exchange_code(
+                 "valid_code",
+                 "http://127.0.0.1:4000/oauth/callbacks/tidal",
+                 "pkce_verifier"
+               )
+
+      assert user_session.access_token == access_token
+      assert user_session.refresh_token == "new_refresh_token"
+      assert user_session.user_id == "12345"
+      assert user_session.country_code == "NO"
+      assert user_session.expires_at > System.system_time(:second)
+    end
+
+    @tag :capture_log
+    test "blows up loudly when the JWT is missing the cc claim" do
+      # Deliberate (ADR-004 §1): a missing claim must fail sign-in, not
+      # silently build a broken session.
+      access_token = jwt(%{"uid" => 12_345})
+
+      Req.Test.expect(MyTidalStub, fn conn ->
+        Req.Test.json(conn, %{
+          "access_token" => access_token,
+          "refresh_token" => "new_refresh_token",
+          "expires_in" => 14_400
+        })
+      end)
+
+      assert_raise KeyError, fn ->
+        ExternalClient.exchange_code("valid_code", "http://127.0.0.1:4000/oauth/callbacks/tidal", "v")
+      end
+    end
+
+    @tag :capture_log
+    test "returns error with invalid code" do
+      Req.Test.expect(MyTidalStub, fn conn ->
+        Req.Test.json(%{conn | status: 400}, %{
+          "error" => "invalid_grant",
+          "error_description" => "Authorization code expired"
+        })
+      end)
+
+      assert {:error, :invalid_code} =
+               ExternalClient.exchange_code("expired_code", "http://127.0.0.1:4000/oauth/callbacks/tidal", "v")
+    end
+
+    @tag :capture_log
+    test "returns error on unexpected status" do
+      Req.Test.expect(MyTidalStub, fn conn ->
+        Plug.Conn.send_resp(conn, 500, "Internal Server Error")
+      end)
+
+      assert {:error, {:unexpected_status, 500, _}} =
+               ExternalClient.exchange_code("valid_code", "http://127.0.0.1:4000/oauth/callbacks/tidal", "v")
+    end
+  end
+
+  describe "with expired token" do
+    setup %{user_session: user_session} do
+      SessionSupervisor.stop_user_token(@user_id)
+
+      {:ok, pid} =
+        SessionSupervisor.start_user_token(@user_id, %{user_session | access_token: "expired_access_token"})
+
+      on_exit(fn -> SessionSupervisor.stop_user_token(@user_id) end)
+
+      {:ok, session_pid: pid}
+    end
+
+    test "handles 401 responses by refreshing the token and retrying once",
+         %{user_session: user_session, session_pid: pid} do
+      expect(MockClient, :refresh_token, fn "refresh_token" ->
+        {:ok, %{access_token: "fresh_access_token", expires_in: 14_400}}
+      end)
+
+      # Refreshing happens in the SessionManager process, so it must be
+      # explicitly allowed to use this test's mock expectations.
+      allow(MockClient, self(), pid)
+
+      Req.Test.expect(MyTidalStub, fn conn ->
+        Plug.Conn.send_resp(conn, 401, "")
+      end)
+
+      Req.Test.expect(MyTidalStub, fn conn ->
+        assert ["Bearer fresh_access_token"] = Plug.Conn.get_req_header(conn, "authorization")
+
+        json_api_resp(
+          conn,
+          200,
+          search_response([
+            %{id: "251380837", title: "Dramamine", artists: [%{id: "9x1", name: "Modest Mouse"}]}
+          ])
+        )
+      end)
+
+      assert %{track_id: "251380837"} =
+               ExternalClient.search_for_track(user_session, "Modest Mouse", "Dramamine")
+    end
+
+    @tag :capture_log
+    test "returns error when the token refresh fails",
+         %{user_session: user_session, session_pid: pid} do
+      expect(MockClient, :refresh_token, fn _refresh_token ->
+        {:error, :invalid_token}
+      end)
+
+      allow(MockClient, self(), pid)
+
+      Req.Test.expect(MyTidalStub, fn conn ->
+        Plug.Conn.send_resp(conn, 401, "")
+      end)
+
+      assert {:error, :token_refresh_failed} =
+               ExternalClient.create_playlist(user_session, "Test Playlist", "Test Description")
+    end
+  end
+end

--- a/test/setlistify/tidal/api_test.exs
+++ b/test/setlistify/tidal/api_test.exs
@@ -5,8 +5,92 @@ defmodule Setlistify.Tidal.APITest do
 
   alias Setlistify.Tidal.API
   alias Setlistify.Tidal.API.MockClient
+  alias Setlistify.Tidal.UserSession
 
   setup :verify_on_exit!
+
+  setup do
+    user_session = %UserSession{
+      access_token: "token",
+      refresh_token: "refresh_token",
+      expires_at: System.system_time(:second) + 14_400,
+      user_id: "12345",
+      country_code: "US"
+    }
+
+    {:ok, user_session: user_session}
+  end
+
+  describe "search_for_track/4" do
+    # The application registers :tidal_track_cache in #141; until then (and for
+    # async isolation) each test run starts it here.
+    setup do
+      start_supervised!({Cachex, name: :tidal_track_cache})
+      :ok
+    end
+
+    test "delegates to the impl through the cache", %{user_session: user_session} do
+      expect(MockClient, :search_for_track, 1, fn _session, "Modest Mouse", "Dramamine", nil ->
+        %{track_id: "251380837"}
+      end)
+
+      assert %{track_id: "251380837"} =
+               API.search_for_track(user_session, "Modest Mouse", "Dramamine")
+    end
+
+    test "caches results so repeat searches skip the impl", %{user_session: user_session} do
+      expect(MockClient, :search_for_track, 1, fn _session, _artist, _track, _cover ->
+        %{track_id: "251380837"}
+      end)
+
+      assert %{track_id: "251380837"} =
+               API.search_for_track(user_session, "Modest Mouse", "Dramamine", "Cursive")
+
+      # Second identical call must be served from the cache (the mock above
+      # only allows a single invocation).
+      assert %{track_id: "251380837"} =
+               API.search_for_track(user_session, "Modest Mouse", "Dramamine", "Cursive")
+    end
+
+    test "does not cache errors", %{user_session: user_session} do
+      expect(MockClient, :search_for_track, 2, fn _session, _artist, _track, _cover ->
+        {:error, {:rate_limited, 4}}
+      end)
+
+      assert {:error, {:rate_limited, 4}} = API.search_for_track(user_session, "a", "t")
+      assert {:error, {:rate_limited, 4}} = API.search_for_track(user_session, "a", "t")
+    end
+  end
+
+  describe "create_playlist/3" do
+    test "delegates to the impl", %{user_session: user_session} do
+      expect(MockClient, :create_playlist, 1, fn _session, "Name", "Description" ->
+        {:ok, %{id: "playlist-id", external_url: "https://tidal.com/playlist/playlist-id"}}
+      end)
+
+      assert {:ok, %{id: "playlist-id"}} = API.create_playlist(user_session, "Name", "Description")
+    end
+  end
+
+  describe "add_tracks_to_playlist/3" do
+    test "delegates to the impl", %{user_session: user_session} do
+      expect(MockClient, :add_tracks_to_playlist, 1, fn _session, "playlist-id", ["track-1"] ->
+        {:ok, :tracks_added}
+      end)
+
+      assert {:ok, :tracks_added} = API.add_tracks_to_playlist(user_session, "playlist-id", ["track-1"])
+    end
+  end
+
+  describe "exchange_code/3" do
+    test "delegates to the impl and returns the session", %{user_session: user_session} do
+      expect(MockClient, :exchange_code, 1, fn "code", "https://127.0.0.1/cb", "verifier" ->
+        {:ok, user_session}
+      end)
+
+      assert {:ok, ^user_session} = API.exchange_code("code", "https://127.0.0.1/cb", "verifier")
+    end
+  end
 
   describe "refresh_token/1" do
     test "delegates to the impl and returns the result" do
@@ -24,6 +108,16 @@ defmodule Setlistify.Tidal.APITest do
       end)
 
       assert {:error, :invalid_token} = API.refresh_token("bad-token")
+    end
+  end
+
+  describe "refresh_to_user_session/1" do
+    test "delegates to the impl and returns the session", %{user_session: user_session} do
+      expect(MockClient, :refresh_to_user_session, 1, fn "refresh-abc" ->
+        {:ok, user_session}
+      end)
+
+      assert {:ok, ^user_session} = API.refresh_to_user_session("refresh-abc")
     end
   end
 end

--- a/test/setlistify/tidal/request_throttle_test.exs
+++ b/test/setlistify/tidal/request_throttle_test.exs
@@ -1,0 +1,101 @@
+defmodule Setlistify.Tidal.RequestThrottleTest do
+  use ExUnit.Case, async: true
+
+  alias Setlistify.Tidal.RequestThrottle
+
+  # Each test starts its own uniquely-named throttle so tests can run async
+  # without touching the globally-named singleton.
+  setup context do
+    name = Module.concat(__MODULE__, context.test)
+    start_supervised!({RequestThrottle, name: name, max_concurrent: 2})
+    {:ok, throttle: name}
+  end
+
+  defp acquire_and_hold(throttle, test_pid) do
+    spawn_link(fn ->
+      RequestThrottle.with_slot(throttle, fn ->
+        send(test_pid, {:in_slot, self()})
+
+        receive do
+          :release -> :ok
+        end
+      end)
+    end)
+  end
+
+  test "returns the function's result", %{throttle: throttle} do
+    assert RequestThrottle.with_slot(throttle, fn -> {:ok, :result} end) == {:ok, :result}
+  end
+
+  test "queues calls above the cap until a slot frees up", %{throttle: throttle} do
+    test_pid = self()
+
+    acquire_and_hold(throttle, test_pid)
+    acquire_and_hold(throttle, test_pid)
+
+    assert_receive {:in_slot, first}
+    assert_receive {:in_slot, _second}
+
+    # Both slots are held — a third call must queue, not run.
+    acquire_and_hold(throttle, test_pid)
+    refute_receive {:in_slot, _third}, 100
+
+    # Releasing one slot lets the queued call through.
+    send(first, :release)
+    assert_receive {:in_slot, _third}
+  end
+
+  test "releases the slot when the holder crashes", %{throttle: throttle} do
+    test_pid = self()
+
+    holder =
+      spawn(fn ->
+        RequestThrottle.with_slot(throttle, fn ->
+          send(test_pid, {:in_slot, self()})
+
+          receive do
+            :never -> :ok
+          end
+        end)
+      end)
+
+    assert_receive {:in_slot, ^holder}
+    acquire_and_hold(throttle, test_pid)
+    assert_receive {:in_slot, _second}
+
+    # Both slots held; kill one holder mid-flight and the throttle should
+    # recover the slot for the next caller.
+    Process.exit(holder, :kill)
+    acquire_and_hold(throttle, test_pid)
+    assert_receive {:in_slot, _third}
+  end
+
+  test "releases the slot when the function raises", %{throttle: throttle} do
+    assert_raise RuntimeError, fn ->
+      RequestThrottle.with_slot(throttle, fn -> raise "boom" end)
+    end
+
+    assert RequestThrottle.with_slot(throttle, fn -> :still_works end) == :still_works
+  end
+
+  test "emits a queue-time telemetry event on acquire", %{throttle: throttle} do
+    handler_id = {__MODULE__, :telemetry_test}
+    test_pid = self()
+
+    :telemetry.attach(
+      handler_id,
+      [:setlistify, :music_service, :request_throttle, :acquired],
+      fn _event, measurements, metadata, _config ->
+        send(test_pid, {:telemetry, measurements, metadata})
+      end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    RequestThrottle.with_slot(throttle, fn -> :ok end)
+
+    assert_receive {:telemetry, %{queue_time: queue_time}, %{music_service: "tidal"}}
+    assert is_integer(queue_time) and queue_time >= 0
+  end
+end


### PR DESCRIPTION
## Summary

Issue #140 — the core Tidal implementation and the deliberate **third data point for #130** (the artist-match + cover-artist-fallback policy is re-derived verbatim from Spotify/Apple Music). Implemented per ADR-004 with all Phase 0 spike updates from the [issue comment](https://github.com/tmr08c/setlistify/issues/140#issuecomment-4652572802) applied.

> **Stacked on #180** (`claude/vigilant-allen-lofn8o`), which carries #138/#139 — the session layer this builds on. This PR's base is that branch so the diff shows only #140's work; retarget to `main` after #180 merges.

### `Tidal.API` — full music-service surface

- Now `@behaviour Setlistify.MusicService.API`: `search_for_track/4` (through `Setlistify.Cache` / `:tidal_track_cache`, identical OTel-propagation pattern to the other providers), `create_playlist/3`, `add_tracks_to_playlist/3`.
- OAuth surface: `exchange_code/3` (with the PKCE `code_verifier`), `refresh_to_user_session/1`, alongside the existing `refresh_token/1`.
- **No `get_embed/1`** — Setlistify-created playlists default to `UNLISTED`, which Tidal's embed player refuses to render; `/playlists` will link out in #144 (ADR-004 §4).

### `Tidal.API.ExternalClient` — JSON:API HTTP implementation

- JSON:API client (`application/vnd.api+json` content-type/accept; Req's `decode_body` handles the `*+json` response automatically — verified in tests that respond with the real content type).
- Path-segment search (`/v2/searchResults/{query}`, strict URL-encoding) with `countryCode` and artist resolution through the **flat** top-level `included` array via `extract_included/3` — always `{type, id}` lookup, never by index, with hardened clauses for missing `relationships`/`included` and dangling artist references (treated as mismatch → cover-fallback path).
- **Policy re-derivation**: `artist_match?/2`, `normalize_artist/1`, and the cover-artist fallback are copied verbatim from the Spotify/Apple Music clients — the #130 evidence.
- `create_playlist/3`: JSON:API body, `accessType: "UNLISTED"`, deterministic `Idempotency-Key`.
- `add_tracks_to_playlist/3`: 20-track chunks, **no `meta.positionBefore`** (spike-verified no-op; natural append is what we want), per-chunk idempotency keys.
- `with_token_refresh/3`: 401 → `SessionManager.refresh_session/1` → retry once.
- Sessions built from the access-token JWT's `uid`/`cc` claims via `decode_jwt_payload!/1` + `Map.fetch!/2` — **no `/v2/users/me` call**, failing loudly on a missing claim, with the ADR-004 §1 fallback recipe documented at the call site. Refresh preserves the stored refresh token (Tidal does not rotate).

### `Tidal.RequestThrottle` — concurrency cap (Phase 0 scope expansion)

- Small semaphore GenServer, `@max_concurrent 4` (inside the spike's measured 8-request burst capacity with headroom). Every `ExternalClient` Req call acquires a slot; calls above the cap queue instead of firing-and-429ing. Slots are recovered if a holder crashes.
- Emits `[:setlistify, :music_service, :request_throttle, :acquired]` with a `queue_time` measurement and `%{music_service: "tidal"}` metadata so the #146 review can tune the cap.
- Fully encapsulated in the Tidal subtree — Spotify and Apple Music are untouched. (The supervision-tree child + `:tidal_track_cache` registration land in #141 per the plan; tests start both locally.)

### 429 surfacing + telemetry conventions

- 429s that occur despite the cap return `{:error, {:rate_limited, retry_after}}` (parsed from `Retry-After`, `nil` if absent). No retry at this layer.
- Recorded as semconv `http.status_code` + an `http.rate_limited` span event carrying `http.response.header.retry_after` — **no `tidal.*` attribute namespace**; provider identity stays in `peer.service`.
- `MusicService.API`'s callback error union widens to `atom() | {atom(), term()}` so the 2-tuple fits the shared behaviour; Spotify/Apple Music keep their bare-atom errors unchanged.

## Decisions called out by the issue

- **Idempotency-Key value strategy** (flagged as an open question in ADR-004): deterministic SHA-256 of `(user_id, name, description)` for creates and `(playlist_id, chunk tracks)` per add-tracks chunk. Retries of the same logical operation dedupe server-side; colliding on genuinely identical requests is exactly the duplicate-prevention we want. `add_tracks_to_playlist/3` **does** carry chunk-level keys — with 20-track chunking + rate-limit retries, they prevent double-adds when the server processed a request but the response was lost.
- `add_track_chunk` accepts 200/201/204 as success — Tidal's docs don't pin the relationship-add status code, and any of the three is an unambiguous success for this call.

## Test plan

- [x] `MIX_ENV=test mix precommit` — compile `--warnings-as-errors`, `deps.unlock --unused`, `format`, `credo --strict`, all green
- [x] `mix test` — **1 doctest, 344 tests, 0 failures** (38 new: `RequestThrottle` semantics incl. crash recovery + telemetry; `Tidal.API` delegation/caching; `ExternalClient` search/create/add-tracks/OAuth incl. JSON:API `included` edge cases, 429 surfacing, chunking, idempotency-key determinism, 401-refresh-retry)
- [ ] Reviewer: the idempotency-key strategy above is the one judgement call the issue deferred to PR time — flag if you'd rather scope creates by setlist id too

Refs #140. Also touches #130 (evidence point) and #146 (throttle telemetry consumer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QPW1G1j3rqU8WZU9bRz9im

---
_Generated by [Claude Code](https://claude.ai/code/session_01QPW1G1j3rqU8WZU9bRz9im)_